### PR TITLE
docs: define Hybrid GitFlow branching strategy, SemVer and release flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,18 @@ Before creating or changing code, always consult:
 
 ## 2) Non-negotiable rules
 
+### Git workflow (branching)
+Follow the **Hybrid GitFlow** strategy defined in `docs/engineer-guidelines.md` → section **Git Workflow** and `docs/adr/0006-branching-strategy.md`.
+
+**Rules for agents:**
+- Always create branches from `develop` — **never from `main`**
+- Never commit directly to `main` or `develop`
+- Branch naming: `feature/<issue-number>-<slug>`, `fix/<issue-number>-<slug>`, `chore/<slug>`
+- Commit messages must follow **Conventional Commits** with monorepo scopes:
+  `feat(backend): ...`, `fix(database): ...`, `test(integration-tests): ...`
+- Always add `Refs #<issue-number>` at the end of commit messages
+- Migrations must be committed in the same branch/PR as the backend code that requires them
+
 ### Do NOT invent
 - Do not invent endpoints not described in `docs/api-spec.md`
 - Do not invent tables/columns not described in `docs/database.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Este projeto usa [GitHub Releases](https://github.com/jaisonschmidt/dude-course/releases) como changelog oficial.
+
+Para o histórico completo de mudanças por versão, consulte as releases publicadas no repositório.
+
+---
+
+## Unreleased
+
+Changes merged to `develop` but not yet promoted to a `release/vX.Y.Z` branch.
+
+See open issues and PRs for in-progress work.
+
+---
+
+> **Workflow**: features are released following the Hybrid GitFlow strategy.
+> See `docs/engineer-guidelines.md` → section **Git Workflow** for details.

--- a/docs/adr/0006-branching-strategy.md
+++ b/docs/adr/0006-branching-strategy.md
@@ -1,0 +1,163 @@
+# ADR-0006: Estratégia de Branching — Hybrid GitFlow
+
+## Status
+Accepted
+
+## Contexto
+
+O projeto Dude Course é um **monorepo pnpm workspaces** com 4 pacotes (`backend`, `frontend`, `database`, `integration-tests`) e múltiplos ambientes de execução definidos na ADR-0005: desenvolvimento local, testes (CI), homologação (HML/staging) e produção.
+
+O time é composto por desenvolvedores humanos e agentes de IA (squad de 11 agentes, conforme `AGENTS.md`), trabalhando em paralelo em features distintas. Sem uma estratégia de branching formalizada, surgem riscos de:
+
+- Código não validado promovido diretamente para produção
+- Impossibilidade de separar o que está em staging do que está em produção
+- Inconsistência nas mensagens de commit, dificultando rastreabilidade e automação de changelog
+- Agentes de IA sem regras claras sobre em qual branch trabalhar, causando PRs conflitantes ou commits diretos em `main`
+- Ausência de processo de versionamento semântico e releases rastreáveis
+
+O projeto precisa de uma estratégia que equilibre **simplicidade para o MVP** com **suporte nativo a múltiplos ambientes** e **releases semânticas**.
+
+### Alternativas consideradas
+
+#### 1. GitHub Flow
+
+Modelo linear com apenas `main` e branches de feature curtas. Cada merge em `main` dispara deploy.
+
+**Prós:**
+- Muito simples — poucos branches, fácil de entender
+- Ideal para deploy contínuo com apenas um ambiente de produção
+
+**Contras:**
+- Não suporta nativamente staging vs. produção como estágios separados
+- Sem conceito de `release/*` — não permite estabilizar uma versão antes de produção
+- Inadequado para o contexto do projeto, que tem HML e produção como ambientes distintos (ADR-0005)
+
+#### 2. Trunk-Based Development
+
+Todo o time trabalha em `main` (trunk) com feature branches muito curtas (horas, não dias) e feature flags para controlar exposição.
+
+**Prós:**
+- Minimiza conflitos de merge — integração contínua real
+- Altamente eficiente quando CI/CD é maduro
+
+**Contras:**
+- Exige feature flags para cada feature em andamento — overhead para MVP
+- Requer CI extremamente maduro e rápido (< 10 min) para ser viável
+- Agentes de IA criam branches de feature baseados em issues — não se encaixam no modelo de commits diretamente no trunk
+- Risco elevado de instabilidade em `main` sem a disciplina de flag management
+
+#### 3. Gitflow Clássico
+
+Modelo completo com `main`, `develop`, `feature/*`, `release/*`, `hotfix/*` e `support/*`.
+
+**Prós:**
+- Separação muito clara de responsabilidades por branch
+- Suporte total a releases paralelas e hotfixes
+- Amplamente documentado e suportado por ferramentas
+
+**Contras:**
+- Verboso demais para MVP — branches de longa duração acumulam divergências
+- `support/*` desnecessário nesta fase
+- Merge de `release` de volta para `develop` e `main` é burocrático para time pequeno
+
+#### 4. Hybrid GitFlow ✅ (escolhido)
+
+Adaptação simplificada do Gitflow Clássico: mantém `develop` como branch de integração e staging, e `release/*` para promoção à produção, removendo branches de longa duração desnecessárias (`support/*`) e fixando estratégias de merge por tipo de branch.
+
+**Prós:**
+- Separação natural entre staging (`develop`) e produção (`main`) — alinhado à ADR-0005
+- `release/*` permite estabilização antes da produção sem congelar `develop`
+- Regras simples o suficiente para agentes de IA seguirem sem ambiguidade
+- `hotfix/*` garante correções críticas sem passar por `develop`
+- SemVer e GitHub Releases se encaixam naturalmente no fluxo de `release/*`
+
+**Contras:**
+- Mais branches do que GitHub Flow — mitigado por branch protection e automação
+- Requer disciplina de merge-back de `release` para `develop` — mitigado por checklist de DoD
+
+## Decisão
+
+Adotar **Hybrid GitFlow** (GitFlow-lite) como estratégia de branching do projeto Dude Course.
+
+### Modelo de branches
+
+```
+main  ←── release/v1.2.0  ←── develop  ←── feature/42-enrollment
+ ↑                                    ←── fix/55-login-crash
+ └──── hotfix/99-payment-null               chore/ci-add-lint
+```
+
+| Branch | Propósito | Criado a partir de | Merge destino | Estratégia de merge |
+|---|---|---|---|---|
+| `main` | Código em produção. Sempre estável e tagueado | — | — | merge commit |
+| `develop` | Integração contínua. Deploy automático para HML | `main` (criado 1x) | via `release/*` | — |
+| `feature/<N>-<slug>` | Novas funcionalidades | `develop` | `develop` | squash merge |
+| `fix/<N>-<slug>` | Correções não-críticas | `develop` | `develop` | squash merge |
+| `chore/<slug>` | Infra, docs, manutenção | `develop` | `develop` | squash merge |
+| `release/vX.Y.Z` | Release candidate | `develop` | `main` + `develop` | merge commit (ambos) |
+| `hotfix/<N>-<slug>` | Correção crítica em produção | `main` | `main` + `develop` | merge commit (ambos) |
+
+### Conventional Commits (monorepo-aware)
+
+Adotar a especificação [Conventional Commits](https://www.conventionalcommits.org/) com escopos específicos ao monorepo:
+
+```
+<type>(<scope>): <descrição curta>
+
+[body opcional]
+
+Refs #<issue-number>
+```
+
+**Tipos válidos:** `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`, `build`
+
+**Escopos do monorepo:** `backend`, `frontend`, `database`, `integration-tests`, `ci`, `docs`
+
+### Versionamento SemVer
+
+| Incremento | Quando usar |
+|---|---|
+| `MAJOR` | Breaking change de API, migration destrutiva incompatível, mudança estrutural |
+| `MINOR` | Nova feature backward-compatible |
+| `PATCH` | Bugfix, hotfix, ajuste sem quebra de contrato |
+
+Tags no formato `vMAJOR.MINOR.PATCH` (ex.: `v1.2.3`) criadas no `main`.
+
+### GitHub Releases como changelog oficial
+
+GitHub Releases é adotado como fonte de verdade para o changelog do projeto. Cada tag `vX.Y.Z` deve ser acompanhada de uma Release publicada com:
+- Lista de features, fixes e breaking changes (referenciando issues/PRs)
+- Link para o Milestone fechado
+
+### Uso de Milestones
+
+Cada versão planejada (`v0.1.0`, `v1.0.0`, etc.) deve ter um Milestone no GitHub. Issues são atribuídas ao Milestone correspondente. O Milestone é fechado quando a `release/vX.Y.Z` é mergeada em `main`.
+
+## Consequências
+
+### Positivas
+- Separação explícita entre staging (`develop`) e produção (`main`) — alinha-se ao ADR-0005
+- Agentes de IA têm regra não-ambígua: sempre partir de `develop`, nunca de `main`
+- Rastreabilidade completa: cada commit referencia issue via `Refs #N`
+- `release/*` permite bugfixes pré-release sem bloquear novas features em `develop`
+- SemVer + GitHub Releases criam histórico auditável de versões
+- Hotfixes têm caminho seguro sem passar por todo o ciclo de release
+
+### Negativas
+- Requer disciplina de merge-back (`release` e `hotfix` → `develop`) — risco de regressão se esquecido
+- Mais branches simultâneos do que GitHub Flow — pode ser confuso sem branch protection configurada
+
+### Mitigações
+- Branch protection em `main` e `develop` impede commits diretos e força PRs com CI verde
+- DoD (`docs/engineer-guidelines.md`) inclui checklist de merge-back obrigatório
+- Regras documentadas em `docs/engineer-guidelines.md` e `.github/copilot-instructions.md` orientam agentes
+
+## Notas
+
+- Relacionado a: ADR-0005 (`docs/adr/0005-database-environments.md`) — ambientes e migrations
+- Impacta: `docs/engineer-guidelines.md`, `.github/copilot-instructions.md`
+- Referências:
+  - [Gitflow Workflow – Atlassian](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
+  - [Conventional Commits](https://www.conventionalcommits.org/)
+  - [Semantic Versioning](https://semver.org/)
+  - [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)

--- a/docs/engineer-guidelines.md
+++ b/docs/engineer-guidelines.md
@@ -136,16 +136,165 @@ Requisitos mínimos para o logger:
 
 ## 🔁 Git Workflow
 
-- Branches:
-  - `main`: estável
-  - `feat/<tema>`: features
-  - `fix/<tema>`: correções
-  - `chore/<tema>`: manutenção
-- PR obrigatório para merge em `main`.
-- PR deve incluir:
-  - descrição do que mudou
-  - checklist de testes
-  - link de issue (se houver)
+A estratégia de branching adotada é o **Hybrid GitFlow** (GitFlow-lite para monorepo).
+Decisão registrada em: `docs/adr/0006-branching-strategy.md`
+
+### Modelo de branches
+
+```
+main  ←── release/v1.2.0  ←── develop  ←── feature/42-enrollment
+ ↑                                    ←── fix/55-login-crash
+ └──── hotfix/99-payment-null               chore/ci-add-lint
+```
+
+| Branch | Propósito | Criado a partir de | Merge destino | Estratégia |
+|---|---|---|---|---|
+| `main` | Produção. Sempre estável e tagueado | — | — | merge commit |
+| `develop` | Integração. Deploy automático para HML | `main` (1x) | via `release/*` | — |
+| `feature/<N>-<slug>` | Novas funcionalidades | `develop` | `develop` | squash merge |
+| `fix/<N>-<slug>` | Correções não-críticas | `develop` | `develop` | squash merge |
+| `chore/<slug>` | Infra, docs, manutenção | `develop` | `develop` | squash merge |
+| `release/vX.Y.Z` | Release candidate | `develop` | `main` + `develop` | merge commit |
+| `hotfix/<N>-<slug>` | Correção crítica em produção | `main` | `main` + `develop` | merge commit |
+
+### Nomenclatura obrigatória
+
+Formato: `<tipo>/<número-da-issue>-<slug-descritivo>`
+
+```
+feature/42-course-enrollment
+fix/55-login-crash
+chore/ci-add-lint
+hotfix/99-payment-null-pointer
+release/v1.2.0
+```
+
+- O número da issue é obrigatório em `feature/*`, `fix/*` e `hotfix/*`
+- O slug deve ser em `kebab-case`, descritivo e curto (máx. ~5 palavras)
+
+### Fluxo: Feature → Staging → Produção
+
+```
+1. Cria feature/<N>-<slug> a partir de develop
+2. Implementa (qualquer pacote do monorepo: backend/, frontend/, database/, integration-tests/)
+   └── Migrations SEMPRE commitadas junto com o código que as exige (ADR-0005)
+3. Abre PR para develop
+   └── CI: build + unit tests + integration tests + prisma migrate deploy (HML efêmero)
+4. ≥1 aprovação → squash merge para develop
+5. develop em HML → validação pela equipe (critérios de aceitação da issue)
+6. Quando develop estável para release:
+   a. Cria release/vX.Y.Z a partir de develop
+   b. Apenas bugfixes são permitidos na release branch
+   c. Atualiza CHANGELOG.md / GitHub Release draft
+   d. Fecha Milestone vX.Y.Z
+7. PR: release/vX.Y.Z → main (merge commit)
+8. Tag vX.Y.Z criada em main → GitHub Release publicada
+9. CI: prisma migrate deploy em produção → deploy de produção
+10. OBRIGATÓRIO: release/vX.Y.Z mergeado de volta para develop
+```
+
+### Fluxo de Hotfix (bug crítico em produção)
+
+```
+1. Cria hotfix/<N>-<slug> a partir de main
+2. Corrige o bug (inclui teste regressivo)
+3. PR: hotfix → main (merge commit) → incrementa PATCH → tag vX.Y.(Z+1)
+4. GitHub Release publicada para o patch
+5. OBRIGATÓRIO: PR hotfix → develop (sincronização imediata)
+```
+
+**Quando usar hotfix?** Apenas quando um bug em produção causa impacto crítico e não pode aguardar o próximo ciclo de release.
+
+### Conventional Commits
+
+Adotar a especificação [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <descrição curta>
+
+[body opcional — contexto adicional]
+
+Refs #<issue-number>
+```
+
+**Tipos válidos:**
+
+| Tipo | Quando usar |
+|---|---|
+| `feat` | Nova funcionalidade |
+| `fix` | Correção de bug |
+| `chore` | Manutenção, infra, tooling |
+| `docs` | Apenas documentação |
+| `refactor` | Refatoração sem mudança de comportamento |
+| `test` | Adição ou correção de testes |
+| `perf` | Melhoria de performance |
+| `ci` | Mudanças em CI/CD |
+| `build` | Sistema de build, dependências |
+
+**Escopos do monorepo** (obrigatório quando aplicável):
+
+`backend` · `frontend` · `database` · `integration-tests` · `ci` · `docs`
+
+**Exemplos:**
+
+```
+feat(backend): add course enrollment endpoint Refs #23
+fix(database): fix migration for lesson_progress Refs #31
+chore(ci): add prisma migrate deploy step for HML Refs #14
+docs(engineer-guidelines): update git workflow section Refs #14
+test(integration-tests): add enrollment e2e test Refs #23
+```
+
+**Breaking changes:** adicionar `!` após o tipo e incluir `BREAKING CHANGE:` no footer:
+
+```
+feat(backend)!: change enrollment API response shape Refs #45
+
+BREAKING CHANGE: field `courseId` renamed to `course_id` in enrollment response.
+```
+
+### Versionamento Semântico (SemVer)
+
+Formato: `vMAJOR.MINOR.PATCH` (ex.: `v1.2.3`)
+
+| Incremento | Quando usar | Exemplo |
+|---|---|---|
+| `MAJOR` | Breaking change de API, migration destrutiva, mudança estrutural | `v1.0.0 → v2.0.0` |
+| `MINOR` | Nova feature backward-compatible | `v1.0.0 → v1.1.0` |
+| `PATCH` | Bugfix, hotfix, ajuste sem quebra | `v1.0.0 → v1.0.1` |
+
+Milestones iniciais planejados: `v0.1.0` (MVP backend), `v0.2.0` (MVP frontend), `v1.0.0` (produção).
+
+### Tags e GitHub Releases
+
+1. Tags são criadas **exclusivamente em `main`** via PR de `release/vX.Y.Z`
+2. Formato da tag: `vMAJOR.MINOR.PATCH`
+3. Cada tag deve ter uma **GitHub Release publicada** com:
+   - Resumo das mudanças (features, fixes, breaking changes)
+   - Links para issues/PRs incluídos
+   - Link para o Milestone fechado
+4. **GitHub Releases é o changelog oficial** — ver `CHANGELOG.md` na raiz
+5. Milestones do GitHub agrupam issues por versão planejada e são fechados no momento da release
+
+### Branch Protection Rules (recomendado)
+
+**`main`:**
+- Require pull request with ≥1 approval before merging
+- Require status checks to pass: `ci/build`, `ci/unit-tests`, `ci/integration-tests`
+- Require branches to be up to date before merging
+- No force pushes, no direct commits, no deletions
+
+**`develop`:**
+- Require pull request with ≥1 approval before merging
+- Require status checks to pass: `ci/build`, `ci/unit-tests`
+- No force pushes
+
+### Considerações específicas para monorepo
+
+- **Um PR pode e deve tocar múltiplos pacotes** — ex.: `database/` + `backend/` + `integration-tests/` em um único PR de feature
+- **Migrations** devem ser versionadas **no mesmo commit** que o código de backend que as requer (ADR-0005)
+- **Tags são no nível raiz** — o monorepo é versionado como uma unidade, não por pacote
+- **CI detecta pacotes alterados** para otimizar jobs, mas migrations e integration-tests sempre rodam
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves #14

Defines and documents the complete **Hybrid GitFlow** branching strategy for the `dude-course` monorepo, including SemVer versioning, Conventional Commits, release flow, and AI agent guidance.

---

## Files changed

| File | Action | Purpose |
|---|---|---|
| `docs/adr/0006-branching-strategy.md` | ✅ Created | ADR with status `Accepted` — 3 alternatives analyzed, Hybrid GitFlow decision justified |
| `docs/engineer-guidelines.md` | ✅ Updated | Section `🔁 Git Workflow` fully rewritten with diagram, tables, flows, SemVer, Conventional Commits |
| `.github/copilot-instructions.md` | ✅ Updated | Section 2 — Git workflow (branching) block for AI agents with non-negotiable rules |
| `CHANGELOG.md` | ✅ Created | Stub at repo root pointing to GitHub Releases as official changelog |

---

## What was decided

- **Strategy**: Hybrid GitFlow (GitFlow-lite adapted for pnpm monorepo)
- **Branch model**: `main` (prod) ← `release/vX.Y.Z` ← `develop` (HML) ← `feature/*`, `fix/*`, `chore/*`
- **Hotfixes**: `main` → `hotfix/*` → back to `main` + `develop`
- **Merge strategy**: squash for feature/fix/chore → develop; merge commit for release/hotfix → main
- **Versioning**: SemVer `vMAJOR.MINOR.PATCH` with GitHub Releases as official changelog
- **Commits**: Conventional Commits with monorepo scopes (`backend`, `frontend`, `database`, `integration-tests`, `ci`, `docs`)
- **AI agents**: always branch from `develop`, never commit to `main` or `develop` directly

---

## Definition of Done

- [x] Code follows `docs/architecture.md` — N/A (docs only)
- [x] `docs/adr/0006-branching-strategy.md` created with status `Accepted`
- [x] `docs/engineer-guidelines.md` updated — Git Workflow section complete
- [x] `.github/copilot-instructions.md` updated — agent rules for branching
- [x] `CHANGELOG.md` created at repo root
- [x] All 5 acceptance criteria validated by QA agent (see issue #14 comments)

---

## Out of scope (pending manual GitHub configuration)

- [ ] Configure Branch Protection Rules on `main` and `develop` in GitHub Settings
- [ ] Create Milestones: `v0.1.0`, `v0.2.0`, `v1.0.0`
- [ ] Create labels: `breaking-change`, `release`, `hotfix`

> These items are tracked in issue #14 subtasks.