### PR TITLE
docs: adicionar seção \"Como Rodar\" no README raiz e criar READMEs por pacote

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Consulte `docs/engineer-guidelines.md` (seção ADRs) para o processo completo.
 ### 6. Instruções para uso de IA
 
 | Arquivo | Propósito |
-|---------|-----------|
+|---------|----------|
 | `.github/copilot-instructions.md` | Instruções gerais para Copilot |
 | `.github/instructions/backend-architecture.instructions.md` | Limites de camada e naming |
 | `.github/instructions/database-migrations.instructions.md` | Padrões de migration |
@@ -73,6 +73,79 @@ Consulte `docs/engineer-guidelines.md` (seção ADRs) para o processo completo.
 | `.github/instructions/api-controllers.instructions.md` | Formato de response e validação |
 | `.github/instructions/security.instructions.md` | Auth, JWT, validação |
 | `.github/instructions/frontend-pages.instructions.md` | Patterns do framework frontend |
+
+## 🚀 Como Rodar
+
+### Pré-requisitos
+
+- **Node.js ≥ 24**
+- **pnpm ≥ 10**
+- **Docker + Docker Compose**
+
+### Quick Start
+
+1. Clone o repositório:
+   ```bash
+   git clone <repo-url>
+   cd dude-course
+   ```
+
+2. Instale as dependências do monorepo:
+   ```bash
+   pnpm install
+   ```
+
+3. Suba o MySQL via Docker:
+   ```bash
+   pnpm dev:db
+   ```
+
+4. Copie os arquivos de variáveis de ambiente:
+   ```bash
+   cp backend/.env.example backend/.env
+   cp frontend/.env.example frontend/.env.local
+   cp database/.env.example database/.env
+   cp integration-tests/.env.example integration-tests/.env
+   ```
+
+5. Execute as migrations e o seed:
+   ```bash
+   pnpm --filter database db:migrate:dev
+   pnpm --filter database db:seed
+   ```
+
+6. Suba o backend e o frontend em paralelo:
+   ```bash
+   pnpm dev
+   ```
+
+### Mapa de Portas
+
+| Serviço | Porta |
+|---------|-------|
+| Frontend | `:3000` |
+| Backend API | `:3001` |
+| MySQL | `:3306` |
+
+### Scripts disponíveis (raiz)
+
+| Script | Descrição |
+|--------|-----------|
+| `pnpm dev` | Sobe backend e frontend em paralelo |
+| `pnpm dev:backend` | Sobe apenas o backend |
+| `pnpm dev:frontend` | Sobe apenas o frontend |
+| `pnpm dev:db` | Sobe o MySQL via Docker (Docker Compose) |
+| `pnpm test` | Roda todos os testes do monorepo |
+| `pnpm build` | Builda todos os pacotes |
+
+> Para setup detalhado (env vars, banco de testes, etc.), consulte [`docs/local-setup.md`](docs/local-setup.md).
+
+### READMEs por pacote
+
+- [backend/README.md](backend/README.md) — API Fastify + MVC
+- [frontend/README.md](frontend/README.md) — Next.js 15 App Router
+- [database/README.md](database/README.md) — Prisma ORM, migrations, seed
+- [integration-tests/README.md](integration-tests/README.md) — Testes de integração
 
 ## Agentes
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,51 @@
+# backend
+
+API HTTP do Dude Course, construída com **Fastify** seguindo o padrão **MVC** em Node.js 24 + TypeScript.
+
+Faz parte do monorepo `dude-course`. Consulte o [README raiz](../README.md) para o setup completo do projeto.
+
+---
+
+## ⚙️ Variáveis de Ambiente
+
+Copie o arquivo de exemplo antes de rodar:
+
+```bash
+cp .env.example .env
+```
+
+| Variável | Descrição | Obrigatória |
+|----------|-----------|-------------|
+| `DATABASE_URL` | URL de conexão MySQL (Prisma) | ✅ |
+| `JWT_SECRET` | Chave secreta para assinatura de tokens (mín. 32 chars) | ✅ |
+| `PORT` | Porta do servidor (padrão: `3001`) | ✅ |
+| `NODE_ENV` | Ambiente de execução (`development`, `production`) | ✅ |
+| `LOG_LEVEL` | Nível de log do Pino (`info`, `debug`, `warn`, `error`) | ✅ |
+| `CORS_ORIGIN` | Origem permitida pelo CORS (ex.: `http://localhost:3000`) | ✅ |
+| `NEW_RELIC_ENABLED` | Ativa o agente New Relic (`true`/`false`) | ❌ opcional |
+| `NEW_RELIC_APP_NAME` | Nome da aplicação no New Relic | ❌ opcional |
+| `NEW_RELIC_LICENSE_KEY` | License key do New Relic | ❌ opcional |
+
+---
+
+## 📜 Scripts
+
+| Script | Comando | Descrição |
+|--------|---------|----------|
+| `dev` | `tsx watch src/server.ts` | Inicia o servidor com hot-reload |
+| `build` | `tsc` | Compila TypeScript para `dist/` |
+| `start` | `node dist/server.js` | Inicia o servidor compilado (produção) |
+| `test` | `vitest run` | Roda os testes unitários |
+| `test:watch` | `vitest` | Roda os testes em modo watch |
+| `test:coverage` | `vitest run --coverage` | Roda os testes com cobertura |
+| `lint` | `tsc --noEmit` | Verifica erros de tipagem TypeScript |
+
+---
+
+## 🚀 Como Rodar Isolado
+
+```bash
+pnpm --filter backend dev
+```
+
+> Certifique-se de que o MySQL está rodando (via `pnpm dev:db` na raiz) e que `backend/.env` está configurado.

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,48 @@
+# database
+
+Pacote responsável pelo schema do banco de dados, migrations e seed do **Dude Course**, usando **Prisma ORM** com **MySQL 8.0**.
+
+Faz parte do monorepo `dude-course`. Consulte o [README raiz](../README.md) para o setup completo do projeto.
+
+---
+
+## ⚙️ Variáveis de Ambiente
+
+Copie o arquivo de exemplo antes de rodar:
+
+```bash
+cp .env.example .env
+```
+
+| Variável | Descrição | Exemplo |
+|----------|-----------|--------|
+| `DATABASE_URL` | URL de conexão MySQL | `mysql://root:root@localhost:3306/dude_course` |
+
+---
+
+## 📜 Scripts (em ordem de uso)
+
+| Script | Comando | Descrição |
+|--------|---------|----------|
+| `db:generate` | `prisma generate` | Gera o Prisma Client a partir do schema |
+| `db:migrate:dev` | `prisma migrate dev` | Cria e aplica migrations (ambiente de desenvolvimento) |
+| `db:seed` | `tsx src/seed.ts` | Popula o banco com dados iniciais |
+| `db:migrate:deploy` | `prisma migrate deploy` | Aplica migrations sem criar novas (produção) |
+| `db:push` | `prisma db push` | Sincroniza schema sem migration (prototipagem) |
+
+> ⚠️ **Produção**: use sempre `db:migrate:deploy`. Nunca rode `db:migrate:dev` em ambientes produtivos.
+
+---
+
+## 🚀 Como Rodar Isolado
+
+```bash
+# 1. Gerar Prisma Client
+pnpm --filter database db:generate
+
+# 2. Aplicar migrations (dev)
+pnpm --filter database db:migrate:dev
+
+# 3. Popular o banco com dados iniciais
+pnpm --filter database db:seed
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,43 @@
+# frontend
+
+Interface web do Dude Course, construída com **Next.js 15** (App Router) + **TypeScript** + **Tailwind CSS**.
+
+Faz parte do monorepo `dude-course`. Consulte o [README raiz](../README.md) para o setup completo do projeto.
+
+---
+
+## ⚙️ Variáveis de Ambiente
+
+Copie o arquivo de exemplo antes de rodar:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variável | Descrição | Padrão |
+|----------|-----------|--------|
+| `NEXT_PUBLIC_API_URL` | URL base da API backend | `http://localhost:3001/api/v1` |
+
+---
+
+## 📜 Scripts
+
+| Script | Comando | Descrição |
+|--------|---------|----------|
+| `dev` | `next dev` | Inicia em modo desenvolvimento com hot-reload |
+| `build` | `next build` | Gera o build de produção |
+| `start` | `next start` | Serve o build de produção |
+| `test` | `vitest run` | Roda os testes unitários |
+| `test:watch` | `vitest` | Roda os testes em modo watch |
+| `test:coverage` | `vitest run --coverage` | Roda os testes com cobertura |
+| `lint` | `tsc --noEmit` | Verifica erros de tipagem TypeScript |
+
+---
+
+## 🚀 Como Rodar Isolado
+
+```bash
+pnpm --filter frontend dev
+```
+
+> O frontend espera o backend rodando em `http://localhost:3001`. Configure `NEXT_PUBLIC_API_URL` em `frontend/.env.local` se a URL for diferente.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,53 @@
+# integration-tests
+
+Pacote de testes de integração do **Dude Course**, executando contra um banco de dados separado (`dude_course_test`) e a API real do backend em execução.
+
+Faz parte do monorepo `dude-course`. Consulte o [README raiz](../README.md) para o setup completo do projeto.
+
+---
+
+## ⚠️ Pré-requisitos
+
+Antes de rodar os testes de integração, certifique-se de que:
+
+1. O banco `dude_course_test` existe e está acessível.
+2. O backend está rodando em `http://localhost:3001` (ou conforme `BACKEND_URL`).
+3. A variável `RUN_INTEGRATION_TESTS=true` está definida no ambiente.
+
+> **Os testes são pulados silenciosamente se `RUN_INTEGRATION_TESTS` não estiver setada como `true`.**
+
+---
+
+## ⚙️ Variáveis de Ambiente
+
+Copie o arquivo de exemplo antes de rodar:
+
+```bash
+cp .env.example .env
+```
+
+| Variável | Descrição | Obrigatória |
+|----------|-----------|-------------|
+| `DATABASE_URL` | URL de conexão com o banco de testes | ✅ |
+| `DATABASE_URL_TEST` | Alias para `DATABASE_URL` (banco de testes) | ✅ |
+| `BACKEND_URL` | URL base do backend em execução | ✅ |
+| `RUN_INTEGRATION_TESTS` | **Deve ser `true`** para os testes não serem pulados | ✅ |
+
+---
+
+## 📜 Scripts
+
+| Script | Comando | Descrição |
+|--------|---------|----------|
+| `test` | `vitest run` | Roda todos os testes de integração |
+| `test:watch` | `vitest` | Roda em modo watch |
+
+---
+
+## 🚀 Como Rodar Isolado
+
+```bash
+RUN_INTEGRATION_TESTS=true pnpm --filter integration-tests test
+```
+
+> Garanta que o banco `dude_course_test` existe e que as migrations foram aplicadas antes de executar os testes.


### PR DESCRIPTION
## Resumo

Implementa todos os critérios de aceite da issue #20 — documentação de onboarding para novos desenvolvedores (e agentes de IA).

---

## Arquivos modificados / criados

| Arquivo | Ação | Descrição |
|---------|------|-----------|
| `README.md` | Modificado | Adicionada seção `## 🚀 Como Rodar` antes de `## Agentes` |
| `backend/README.md` | Criado | Descreve o pacote API Fastify + MVC, variáveis de ambiente, scripts e como rodar isolado |
| `frontend/README.md` | Criado | Descreve o pacote Next.js 15, variável `NEXT_PUBLIC_API_URL`, scripts e como rodar isolado |
| `database/README.md` | Criado | Descreve Prisma ORM, `DATABASE_URL`, scripts em ordem de uso e aviso sobre `migrate:deploy` em produção |
| `integration-tests/README.md` | Criado | Descreve pré-requisitos, variáveis e aviso explícito sobre `RUN_INTEGRATION_TESTS=true` |

> **Nota**: `docs/engineer-guidelines.md` já possui a seção `## 🪝 Git Hooks (Husky + lint-staged)` completa — nenhuma alteração necessária nesse arquivo.

---

## Conteúdo adicionado ao README raiz

- ✅ Pré-requisitos globais (Node.js ≥ 24, pnpm ≥ 10, Docker)
- ✅ Quick Start de 6 passos
- ✅ Mapa de portas (`:3000`, `:3001`, `:3306`)
- ✅ Tabela de scripts disponíveis na raiz
- ✅ Link para `docs/local-setup.md`
- ✅ Links para READMEs de cada pacote

---

## Definition of Done

- [x] Todos os critérios de aceite da issue atendidos
- [x] Conteúdo fiel aos `.env.example` e `package.json` reais de cada pacote
- [x] Sem alterações de código — apenas documentação
- [x] `docs/engineer-guidelines.md` sem modificação (seção de git hooks já existia)

Closes #20