### PR TITLE
feat(#26): Lesson progress tracking with auto-completion

### DIFF
--- a/backend/src/controllers/lesson-progress-controller.ts
+++ b/backend/src/controllers/lesson-progress-controller.ts
@@ -1,0 +1,53 @@
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import type { LessonProgressService } from '../services/lesson-progress-service.js'
+import { LessonProgressParamsSchema } from '../dto/lesson-progress-dto.js'
+import type { LessonProgressResponseDto } from '../dto/lesson-progress-dto.js'
+import { logger } from '../utils/logger.js'
+
+export class LessonProgressController {
+  constructor(private readonly lessonProgressService: LessonProgressService) {}
+
+  async markCompleted(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const params = LessonProgressParamsSchema.parse(request.params)
+
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    const userId = request.user.id
+
+    const result = await this.lessonProgressService.markCompleted(
+      userId,
+      params.courseId,
+      params.lessonId,
+    )
+
+    const data: LessonProgressResponseDto = {
+      id: result.progress.id,
+      userId: result.progress.userId,
+      courseId: result.progress.courseId,
+      lessonId: result.progress.lessonId,
+      completedAt: result.progress.completedAt.toISOString(),
+    }
+
+    logger.info(
+      { requestId: request.id, userId, courseId: params.courseId, lessonId: params.lessonId },
+      'lesson-progress.completed',
+    )
+
+    if (result.autoCompleted) {
+      logger.info(
+        { requestId: request.id, userId, courseId: params.courseId },
+        'enrollment.completed',
+      )
+    }
+
+    return reply.status(200).send({ data, requestId: request.id })
+  }
+}

--- a/backend/src/dto/lesson-progress-dto.ts
+++ b/backend/src/dto/lesson-progress-dto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const LessonProgressParamsSchema = z.object({
+  courseId: z.coerce.number().int().min(1),
+  lessonId: z.coerce.number().int().min(1),
+})
+export type LessonProgressParamsDto = z.infer<typeof LessonProgressParamsSchema>
+
+export interface LessonProgressResponseDto {
+  id: number
+  userId: number
+  courseId: number
+  lessonId: number
+  completedAt: string
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,16 +2,20 @@ import type { FastifyInstance } from 'fastify'
 import { authRoutes } from './auth-routes.js'
 import { courseRoutes } from './course-routes.js'
 import { enrollmentRoutes } from './enrollment-routes.js'
+import { lessonProgressRoutes } from './lesson-progress-routes.js'
 import { AuthController } from '../controllers/auth-controller.js'
 import { CourseController } from '../controllers/course-controller.js'
 import { EnrollmentController } from '../controllers/enrollment-controller.js'
+import { LessonProgressController } from '../controllers/lesson-progress-controller.js'
 import { AuthService } from '../services/auth-service.js'
 import { CourseService } from '../services/course-service.js'
 import { EnrollmentService } from '../services/enrollment-service.js'
+import { LessonProgressService } from '../services/lesson-progress-service.js'
 import { PrismaUserRepository } from '../repositories/user-repository.js'
 import { PrismaCourseRepository } from '../repositories/course-repository.js'
 import { PrismaLessonRepository } from '../repositories/lesson-repository.js'
 import { PrismaEnrollmentRepository } from '../repositories/enrollment-repository.js'
+import { PrismaLessonProgressRepository } from '../repositories/lesson-progress-repository.js'
 
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
   // Composition root: wire dependencies
@@ -19,20 +23,28 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   const courseRepository = new PrismaCourseRepository()
   const lessonRepository = new PrismaLessonRepository()
   const enrollmentRepository = new PrismaEnrollmentRepository()
+  const lessonProgressRepository = new PrismaLessonProgressRepository()
 
   const authService = new AuthService(userRepository)
   const courseService = new CourseService(courseRepository, lessonRepository)
   const enrollmentService = new EnrollmentService(enrollmentRepository, courseRepository)
+  const lessonProgressService = new LessonProgressService(
+    lessonProgressRepository,
+    lessonRepository,
+    enrollmentRepository,
+  )
 
   const authController = new AuthController(authService)
   const courseController = new CourseController(courseService)
   const enrollmentController = new EnrollmentController(enrollmentService)
+  const lessonProgressController = new LessonProgressController(lessonProgressService)
 
   await app.register(
     async (api) => {
       await authRoutes(api, authController)
       await courseRoutes(api, courseController)
       await enrollmentRoutes(api, enrollmentController)
+      await lessonProgressRoutes(api, lessonProgressController)
     },
     { prefix: '/api/v1' },
   )

--- a/backend/src/routes/lesson-progress-routes.ts
+++ b/backend/src/routes/lesson-progress-routes.ts
@@ -1,0 +1,14 @@
+import type { FastifyInstance } from 'fastify'
+import type { LessonProgressController } from '../controllers/lesson-progress-controller.js'
+import { authMiddleware } from '../middlewares/auth.js'
+
+export async function lessonProgressRoutes(
+  app: FastifyInstance,
+  controller: LessonProgressController,
+): Promise<void> {
+  app.post(
+    '/courses/:courseId/lessons/:lessonId/progress',
+    { preHandler: [authMiddleware] },
+    (request, reply) => controller.markCompleted(request, reply),
+  )
+}

--- a/backend/src/services/lesson-progress-service.ts
+++ b/backend/src/services/lesson-progress-service.ts
@@ -1,0 +1,86 @@
+import type { LessonProgress } from '../models/lesson-progress.js'
+import type { ILessonProgressRepository } from '../repositories/lesson-progress-repository.js'
+import type { ILessonRepository } from '../repositories/lesson-repository.js'
+import type { IEnrollmentRepository } from '../repositories/enrollment-repository.js'
+import { NotFoundError } from '../models/errors.js'
+import { isUniqueConstraintError } from '../utils/prisma-errors.js'
+
+export class LessonProgressService {
+  constructor(
+    private readonly lessonProgressRepository: ILessonProgressRepository,
+    private readonly lessonRepository: ILessonRepository,
+    private readonly enrollmentRepository: IEnrollmentRepository,
+  ) {}
+
+  async markCompleted(
+    userId: number,
+    courseId: number,
+    lessonId: number,
+  ): Promise<{ progress: LessonProgress; autoCompleted: boolean }> {
+    // 1. Verify lesson exists and belongs to the course
+    const lesson = await this.lessonRepository.findById(lessonId)
+
+    if (!lesson || lesson.courseId !== courseId) {
+      throw new NotFoundError('Lesson not found in this course')
+    }
+
+    // 2. Verify learner is enrolled in the course
+    const enrollment = await this.enrollmentRepository.findByUserAndCourse(userId, courseId)
+
+    if (!enrollment) {
+      throw new NotFoundError('Enrollment not found')
+    }
+
+    // 3. Check if already completed (idempotent)
+    const existing = await this.lessonProgressRepository.findByUserAndLesson(userId, lessonId)
+
+    if (existing) {
+      return { progress: existing, autoCompleted: false }
+    }
+
+    // 4. Create progress record — catch TOCTOU race condition
+    let progress: LessonProgress
+    try {
+      progress = await this.lessonProgressRepository.create({
+        userId,
+        courseId,
+        lessonId,
+      })
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        const raceProgress = await this.lessonProgressRepository.findByUserAndLesson(userId, lessonId)
+        if (raceProgress) {
+          return { progress: raceProgress, autoCompleted: false }
+        }
+      }
+      throw error
+    }
+
+    // 5. Check auto-completion: if all lessons of the course are completed
+    const autoCompleted = await this.checkAutoCompletion(userId, courseId, enrollment.id)
+
+    return { progress, autoCompleted }
+  }
+
+  private async checkAutoCompletion(
+    userId: number,
+    courseId: number,
+    enrollmentId: number,
+  ): Promise<boolean> {
+    const [allLessons, completedProgress] = await Promise.all([
+      this.lessonRepository.findByCourseId(courseId),
+      this.lessonProgressRepository.findByCourseProgress(userId, courseId),
+    ])
+
+    if (allLessons.length === 0) {
+      return false
+    }
+
+    if (completedProgress.length >= allLessons.length) {
+      await this.enrollmentRepository.markCompleted(enrollmentId, new Date())
+      return true
+    }
+
+    return false
+  }
+}

--- a/backend/test/unit/services/lesson-progress-service.spec.ts
+++ b/backend/test/unit/services/lesson-progress-service.spec.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { LessonProgressService } from '../../../src/services/lesson-progress-service.js'
+import type { ILessonProgressRepository } from '../../../src/repositories/lesson-progress-repository.js'
+import type { ILessonRepository } from '../../../src/repositories/lesson-repository.js'
+import type { IEnrollmentRepository } from '../../../src/repositories/enrollment-repository.js'
+import {
+  createLessonFactory,
+  createEnrollmentFactory,
+  createLessonProgressFactory,
+} from '../../helpers/factories.js'
+import { NotFoundError } from '../../../src/models/errors.js'
+
+vi.mock('../../../src/utils/prisma-errors.js', () => ({
+  isUniqueConstraintError: vi.fn(),
+}))
+
+import { isUniqueConstraintError } from '../../../src/utils/prisma-errors.js'
+
+function createMockLessonProgressRepository(): ILessonProgressRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByUserAndLesson: vi.fn(),
+    findByCourseProgress: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function createMockLessonRepository(): Pick<ILessonRepository, 'findById' | 'findByCourseId'> {
+  return {
+    findById: vi.fn(),
+    findByCourseId: vi.fn(),
+  }
+}
+
+function createMockEnrollmentRepository(): Pick<IEnrollmentRepository, 'findByUserAndCourse' | 'markCompleted'> {
+  return {
+    findByUserAndCourse: vi.fn(),
+    markCompleted: vi.fn(),
+  }
+}
+
+describe('LessonProgressService', () => {
+  let service: LessonProgressService
+  let mockProgressRepo: ILessonProgressRepository
+  let mockLessonRepo: ReturnType<typeof createMockLessonRepository>
+  let mockEnrollmentRepo: ReturnType<typeof createMockEnrollmentRepository>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockProgressRepo = createMockLessonProgressRepository()
+    mockLessonRepo = createMockLessonRepository()
+    mockEnrollmentRepo = createMockEnrollmentRepository()
+    service = new LessonProgressService(
+      mockProgressRepo,
+      mockLessonRepo as ILessonRepository,
+      mockEnrollmentRepo as IEnrollmentRepository,
+    )
+  })
+
+  describe('markCompleted', () => {
+    const userId = 42
+    const courseId = 10
+    const lessonId = 5
+
+    it('should create progress record for a valid lesson in an enrolled course', async () => {
+      // Arrange
+      const lesson = createLessonFactory({ id: lessonId, courseId })
+      const enrollment = createEnrollmentFactory({ userId, courseId })
+      const progress = createLessonProgressFactory({ userId, courseId, lessonId })
+
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(enrollment)
+      vi.mocked(mockProgressRepo.findByUserAndLesson).mockResolvedValue(null)
+      vi.mocked(mockProgressRepo.create).mockResolvedValue(progress)
+      vi.mocked(mockLessonRepo.findByCourseId).mockResolvedValue([lesson])
+      vi.mocked(mockProgressRepo.findByCourseProgress).mockResolvedValue([progress])
+      vi.mocked(mockEnrollmentRepo.markCompleted).mockResolvedValue(enrollment)
+
+      // Act
+      const result = await service.markCompleted(userId, courseId, lessonId)
+
+      // Assert
+      expect(result.progress).toEqual(progress)
+      expect(mockProgressRepo.create).toHaveBeenCalledWith({ userId, courseId, lessonId })
+    })
+
+    it('should return existing progress without creating duplicate (idempotent)', async () => {
+      // Arrange
+      const lesson = createLessonFactory({ id: lessonId, courseId })
+      const enrollment = createEnrollmentFactory({ userId, courseId })
+      const existingProgress = createLessonProgressFactory({ id: 99, userId, courseId, lessonId })
+
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(enrollment)
+      vi.mocked(mockProgressRepo.findByUserAndLesson).mockResolvedValue(existingProgress)
+
+      // Act
+      const result = await service.markCompleted(userId, courseId, lessonId)
+
+      // Assert
+      expect(result.progress).toEqual(existingProgress)
+      expect(result.autoCompleted).toBe(false)
+      expect(mockProgressRepo.create).not.toHaveBeenCalled()
+    })
+
+    it('should throw NotFoundError when lesson does not exist', async () => {
+      // Arrange
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(null)
+
+      // Act & Assert
+      await expect(service.markCompleted(userId, courseId, 999)).rejects.toThrow(NotFoundError)
+      await expect(service.markCompleted(userId, courseId, 999)).rejects.toThrow(
+        'Lesson not found in this course',
+      )
+      expect(mockEnrollmentRepo.findByUserAndCourse).not.toHaveBeenCalled()
+    })
+
+    it('should throw NotFoundError when lesson belongs to a different course', async () => {
+      // Arrange
+      const lessonInOtherCourse = createLessonFactory({ id: lessonId, courseId: 999 })
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lessonInOtherCourse)
+
+      // Act & Assert
+      await expect(service.markCompleted(userId, courseId, lessonId)).rejects.toThrow(NotFoundError)
+      expect(mockEnrollmentRepo.findByUserAndCourse).not.toHaveBeenCalled()
+    })
+
+    it('should throw NotFoundError when learner is not enrolled', async () => {
+      // Arrange
+      const lesson = createLessonFactory({ id: lessonId, courseId })
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(null)
+
+      // Act & Assert
+      await expect(service.markCompleted(userId, courseId, lessonId)).rejects.toThrow(NotFoundError)
+      await expect(service.markCompleted(userId, courseId, lessonId)).rejects.toThrow(
+        'Enrollment not found',
+      )
+      expect(mockProgressRepo.findByUserAndLesson).not.toHaveBeenCalled()
+    })
+
+    it('should auto-complete enrollment when all lessons are completed', async () => {
+      // Arrange
+      const lesson1 = createLessonFactory({ id: 1, courseId, position: 1 })
+      const lesson2 = createLessonFactory({ id: 2, courseId, position: 2 })
+      const enrollment = createEnrollmentFactory({ id: 7, userId, courseId })
+      const progress1 = createLessonProgressFactory({ userId, courseId, lessonId: 1 })
+      const progress2 = createLessonProgressFactory({ userId, courseId, lessonId: 2 })
+
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson2)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(enrollment)
+      vi.mocked(mockProgressRepo.findByUserAndLesson).mockResolvedValue(null)
+      vi.mocked(mockProgressRepo.create).mockResolvedValue(progress2)
+
+      // Auto-completion check: all 2 lessons completed
+      vi.mocked(mockLessonRepo.findByCourseId).mockResolvedValue([lesson1, lesson2])
+      vi.mocked(mockProgressRepo.findByCourseProgress).mockResolvedValue([progress1, progress2])
+      vi.mocked(mockEnrollmentRepo.markCompleted).mockResolvedValue({
+        ...enrollment,
+        completedAt: new Date(),
+      })
+
+      // Act
+      const result = await service.markCompleted(userId, courseId, 2)
+
+      // Assert
+      expect(result.autoCompleted).toBe(true)
+      expect(mockEnrollmentRepo.markCompleted).toHaveBeenCalledWith(7, expect.any(Date))
+    })
+
+    it('should NOT auto-complete when not all lessons are completed', async () => {
+      // Arrange
+      const lesson1 = createLessonFactory({ id: 1, courseId, position: 1 })
+      const lesson2 = createLessonFactory({ id: 2, courseId, position: 2 })
+      const lesson3 = createLessonFactory({ id: 3, courseId, position: 3 })
+      const enrollment = createEnrollmentFactory({ userId, courseId })
+      const progress1 = createLessonProgressFactory({ userId, courseId, lessonId: 1 })
+
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson1)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(enrollment)
+      vi.mocked(mockProgressRepo.findByUserAndLesson).mockResolvedValue(null)
+      vi.mocked(mockProgressRepo.create).mockResolvedValue(progress1)
+
+      // Auto-completion check: only 1 of 3 lessons completed
+      vi.mocked(mockLessonRepo.findByCourseId).mockResolvedValue([lesson1, lesson2, lesson3])
+      vi.mocked(mockProgressRepo.findByCourseProgress).mockResolvedValue([progress1])
+
+      // Act
+      const result = await service.markCompleted(userId, courseId, 1)
+
+      // Assert
+      expect(result.autoCompleted).toBe(false)
+      expect(mockEnrollmentRepo.markCompleted).not.toHaveBeenCalled()
+    })
+
+    it('should handle race condition gracefully when concurrent create hits unique constraint', async () => {
+      // Arrange
+      const lesson = createLessonFactory({ id: lessonId, courseId })
+      const enrollment = createEnrollmentFactory({ userId, courseId })
+      const existingProgress = createLessonProgressFactory({ id: 99, userId, courseId, lessonId })
+
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(enrollment)
+      vi.mocked(mockProgressRepo.findByUserAndLesson)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(existingProgress)
+
+      const uniqueError = new Error('Unique constraint failed')
+      vi.mocked(mockProgressRepo.create).mockRejectedValue(uniqueError)
+      vi.mocked(isUniqueConstraintError).mockReturnValue(true)
+
+      // Act
+      const result = await service.markCompleted(userId, courseId, lessonId)
+
+      // Assert
+      expect(result.progress).toEqual(existingProgress)
+      expect(result.autoCompleted).toBe(false)
+    })
+
+    it('should rethrow non-unique-constraint errors from create', async () => {
+      // Arrange
+      const lesson = createLessonFactory({ id: lessonId, courseId })
+      const enrollment = createEnrollmentFactory({ userId, courseId })
+
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(lesson)
+      vi.mocked(mockEnrollmentRepo.findByUserAndCourse).mockResolvedValue(enrollment)
+      vi.mocked(mockProgressRepo.findByUserAndLesson).mockResolvedValue(null)
+
+      const dbError = new Error('Connection refused')
+      vi.mocked(mockProgressRepo.create).mockRejectedValue(dbError)
+      vi.mocked(isUniqueConstraintError).mockReturnValue(false)
+
+      // Act & Assert
+      await expect(service.markCompleted(userId, courseId, lessonId)).rejects.toThrow(
+        'Connection refused',
+      )
+    })
+
+    it('should verify lesson existence before checking enrollment (fail fast)', async () => {
+      // Arrange
+      vi.mocked(mockLessonRepo.findById).mockResolvedValue(null)
+
+      // Act
+      await expect(service.markCompleted(userId, courseId, lessonId)).rejects.toThrow()
+
+      // Assert — enrollment should never be checked
+      expect(mockLessonRepo.findById).toHaveBeenCalledOnce()
+      expect(mockEnrollmentRepo.findByUserAndCourse).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/integration-tests/test/api/lesson-progress.spec.ts
+++ b/integration-tests/test/api/lesson-progress.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * Lesson Progress integration tests.
+ *
+ * Tests: POST /api/v1/courses/:courseId/lessons/:lessonId/progress
+ *   (idempotent mark-complete + auto-completion)
+ *
+ * Requires:
+ *   - A running backend instance (BACKEND_URL, default: http://localhost:3001)
+ *   - A clean test database
+ *   - RUN_INTEGRATION_TESTS=true
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { post } from '../../helpers/request.js'
+import { setupDb, teardownDb, truncateAll, getTestPrisma } from '../../helpers/db.js'
+
+const shouldRun = process.env['RUN_INTEGRATION_TESTS'] === 'true'
+const describeOrSkip = shouldRun ? describe : describe.skip
+
+interface ProgressResponse {
+  data: {
+    id: number
+    userId: number
+    courseId: number
+    lessonId: number
+    completedAt: string
+  }
+  requestId: string
+}
+
+interface ErrorResponse {
+  error: {
+    code: string
+    message: string
+    details?: Array<{ field: string; message: string }>
+    requestId: string
+  }
+}
+
+interface LoginResponse {
+  data: {
+    accessToken: string
+    expiresIn: string
+    user: { id: number; name: string; email: string; role: string }
+  }
+  requestId: string
+}
+
+/**
+ * Seed a published course with lessons. Returns courseId and lessonIds.
+ */
+async function seedCourseWithLessons(
+  lessonCount = 2,
+): Promise<{ courseId: number; lessonIds: number[] }> {
+  const prisma = getTestPrisma()
+
+  await prisma.$executeRaw`
+    INSERT INTO courses (title, description, status, created_at, updated_at)
+    VALUES ('Test Course', 'A test course', 'published', NOW(), NOW())
+  `
+  const courseRows = await prisma.$queryRaw`SELECT LAST_INSERT_ID() as id` as Array<{ id: bigint }>
+  const courseId = Number(courseRows[0]!.id)
+
+  const lessonIds: number[] = []
+  for (let i = 1; i <= lessonCount; i++) {
+    await prisma.$executeRaw`
+      INSERT INTO lessons (course_id, title, youtube_url, position, created_at, updated_at)
+      VALUES (${courseId}, ${`Lesson ${i}`}, ${`https://youtube.com/watch?v=test${i}`}, ${i}, NOW(), NOW())
+    `
+    const lessonRows = await prisma.$queryRaw`SELECT LAST_INSERT_ID() as id` as Array<{
+      id: bigint
+    }>
+    lessonIds.push(Number(lessonRows[0]!.id))
+  }
+
+  return { courseId, lessonIds }
+}
+
+/**
+ * Register + login a user and return their access token and userId.
+ */
+async function registerAndLogin(
+  email = 'learner@example.com',
+  password = 'securepassword123',
+): Promise<{ token: string; userId: number }> {
+  await post('/api/v1/auth/register', {
+    name: 'Test Learner',
+    email,
+    password,
+  })
+
+  const loginRes = await post<LoginResponse>('/api/v1/auth/login', {
+    email,
+    password,
+  })
+
+  return {
+    token: loginRes.body.data.accessToken,
+    userId: loginRes.body.data.user.id,
+  }
+}
+
+/**
+ * Enroll a user in a course. Returns enrollment id.
+ */
+async function enrollUser(courseId: number, token: string): Promise<number> {
+  const res = await post<{ data: { id: number } }>(
+    `/api/v1/courses/${courseId}/enrollments`,
+    {},
+    { Authorization: `Bearer ${token}` },
+  )
+  return res.body.data.id
+}
+
+describeOrSkip('Lesson Progress Endpoints', () => {
+  beforeAll(async () => {
+    await setupDb()
+  })
+
+  beforeEach(async () => {
+    await truncateAll()
+  })
+
+  afterAll(async () => {
+    await teardownDb()
+  })
+
+  // ────────────────────────────────────────
+  // POST /api/v1/courses/:courseId/lessons/:lessonId/progress
+  // ────────────────────────────────────────
+  describe('POST /api/v1/courses/:courseId/lessons/:lessonId/progress', () => {
+    it('AC-01: should return 200 with progress data when marking lesson as completed', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(3)
+      const { token, userId } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      const res = await post<ProgressResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data).toMatchObject({
+        userId,
+        courseId,
+        lessonId: lessonIds[0],
+      })
+      expect(res.body.data.id).toBeTypeOf('number')
+      expect(res.body.data.completedAt).toBeTypeOf('string')
+      expect(res.body.requestId).toBeTypeOf('string')
+    })
+
+    it('AC-02: should return 200 with existing progress when called again (idempotent)', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(2)
+      const { token } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // First call
+      const first = await post<ProgressResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+      expect(first.status).toBe(200)
+
+      // Second call — idempotent
+      const second = await post<ProgressResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+      expect(second.status).toBe(200)
+      expect(second.body.data.id).toBe(first.body.data.id)
+      expect(second.body.data.completedAt).toBe(first.body.data.completedAt)
+    })
+
+    it('AC-02: should not create duplicate progress records in the database', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(2)
+      const { token, userId } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // Mark same lesson twice
+      await post(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+      await post(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      // Verify only one progress record exists
+      const prisma = getTestPrisma()
+      const rows = await prisma.$queryRaw`
+        SELECT COUNT(*) as count FROM lesson_progress
+        WHERE user_id = ${userId} AND lesson_id = ${lessonIds[0]}
+      ` as Array<{ count: bigint }>
+      expect(Number(rows[0]!.count)).toBe(1)
+    })
+
+    it('AC-03: should auto-complete enrollment when all lessons are completed', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(2)
+      const { token, userId } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // Complete lesson 1
+      await post(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      // Complete lesson 2 (last lesson → auto-complete enrollment)
+      await post(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[1]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      // Verify enrollment is marked as completed
+      const prisma = getTestPrisma()
+      const rows = await prisma.$queryRaw`
+        SELECT completed_at FROM enrollments
+        WHERE user_id = ${userId} AND course_id = ${courseId}
+      ` as Array<{ completed_at: Date | null }>
+      expect(rows[0]!.completed_at).not.toBeNull()
+    })
+
+    it('AC-03: should NOT auto-complete when not all lessons are completed', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(3)
+      const { token, userId } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // Complete only lesson 1 of 3
+      await post(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      // Verify enrollment is NOT completed
+      const prisma = getTestPrisma()
+      const rows = await prisma.$queryRaw`
+        SELECT completed_at FROM enrollments
+        WHERE user_id = ${userId} AND course_id = ${courseId}
+      ` as Array<{ completed_at: Date | null }>
+      expect(rows[0]!.completed_at).toBeNull()
+    })
+
+    it('AC-04: should return 404 when lesson does not belong to the course', async () => {
+      const { courseId } = await seedCourseWithLessons(1)
+      const course2 = await seedCourseWithLessons(1) // another course with different lessons
+      const { token } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // Try to mark a lesson from course2 against course1
+      const res = await post<ErrorResponse>(
+        `/api/v1/courses/${courseId}/lessons/${course2.lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('AC-05: should return 404 when learner is not enrolled in the course', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(2)
+      const { token } = await registerAndLogin()
+      // NOT enrolling the user
+
+      const res = await post<ErrorResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('AC-06: should return 401 when no auth token is provided', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(1)
+
+      const res = await post<ErrorResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+      )
+
+      expect(res.status).toBe(401)
+      expect(res.body.error.code).toBe('UNAUTHORIZED')
+      expect(res.body.error.requestId).toBeTypeOf('string')
+    })
+
+    it('AC-06: should return 401 when auth token is invalid', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(1)
+
+      const res = await post<ErrorResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: 'Bearer invalid-token-here' },
+      )
+
+      expect(res.status).toBe(401)
+      expect(res.body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('AC-07: should return 400 for non-numeric courseId', async () => {
+      const { token } = await registerAndLogin()
+
+      const res = await post<ErrorResponse>(
+        '/api/v1/courses/abc/lessons/1/progress',
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('AC-07: should return 400 for non-numeric lessonId', async () => {
+      const { token } = await registerAndLogin()
+
+      const res = await post<ErrorResponse>(
+        '/api/v1/courses/1/lessons/xyz/progress',
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('should include requestId in all responses', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons(1)
+      const { token } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // Success response
+      const successRes = await post<ProgressResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+      expect(successRes.body.requestId).toBeTypeOf('string')
+      expect(successRes.requestId).toBeTypeOf('string')
+
+      // Error response (no auth)
+      const errorRes = await post<ErrorResponse>(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+      )
+      expect(errorRes.body.error.requestId).toBeTypeOf('string')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #26 — **Lesson Progress Tracking + Auto-Completion**.

Adds the `POST /api/v1/courses/:courseId/lessons/:lessonId/progress` endpoint that allows enrolled learners to mark lessons as completed. When all lessons in a course are completed, the enrollment is automatically marked as completed.

## Changes

### New files

| File | Layer | Purpose |
|------|-------|---------|
| `backend/src/dto/lesson-progress-dto.ts` | Interface | Zod validation schemas for path params (`courseId`, `lessonId`) |
| `backend/src/services/lesson-progress-service.ts` | Service | Business logic: idempotent mark-complete + auto-completion check |
| `backend/src/controllers/lesson-progress-controller.ts` | Controller | HTTP handler with auth guard, validation, structured logging |
| `backend/src/routes/lesson-progress-routes.ts` | Routes | Route registration with auth middleware |
| `backend/test/unit/services/lesson-progress-service.spec.ts` | Tests | 10 unit tests covering all business rules |
| `integration-tests/test/api/lesson-progress.spec.ts` | Tests | 12 integration tests covering all acceptance criteria |

### Modified files

| File | Change |
|------|--------|
| `backend/src/routes/index.ts` | Wired `LessonProgressRepository`, `LessonProgressService`, `LessonProgressController`, and registered routes |

## Acceptance Criteria Coverage

- ✅ **AC-01**: Mark lesson as completed → 200 with progress data
- ✅ **AC-02**: Idempotent — duplicate calls return existing progress (no duplicates in DB)
- ✅ **AC-03**: Auto-completion — enrollment marked completed when all lessons done
- ✅ **AC-04**: Lesson not in course → 404
- ✅ **AC-05**: Not enrolled → 404
- ✅ **AC-06**: No auth / invalid token → 401
- ✅ **AC-07**: Non-numeric params → 400 validation error

## Technical Highlights

- **TOCTOU-safe**: Uses try/catch on create with P2002 detection for race conditions
- **Idempotent**: Returns existing record if progress already exists
- **Observability**: Logs `lesson-progress.completed` and `enrollment.completed` domain events with `requestId`
- **Explicit auth guard**: No `request.user!` assertion — returns 401 if missing

## Tests

- **56 unit tests pass** (10 new + 46 existing)
- **12 integration tests** ready (require `RUN_INTEGRATION_TESTS=true`)

Closes #26