### PR TITLE
chore(#41): temporarily disable CI Backend pipeline

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -26,6 +26,9 @@ on:
 
 jobs:
   test-backend:
+    # TEMPORARILY DISABLED — backend fails to start in CI (health check timeout).
+    # See issue #41 for investigation and re-enablement plan.
+    if: false
     name: Test Backend
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Temporarily disables the **CI — Backend** pipeline (`ci-backend.yml`) by adding `if: false` to the `test-backend` job.

## Reason

The backend fails to start during the health check step in GitHub Actions, causing all integration test runs to fail:

```
Backend failed to start in time
Error: Process completed with exit code 1.
```

This does not affect local development — unit tests and lint still run via Husky pre-push hooks.

## What changed

- Added `if: false` to the `test-backend` job in `.github/workflows/ci-backend.yml`
- Added a comment referencing issue #41 for tracking

## Re-enablement

Issue #41 tracks the investigation and re-enablement of this pipeline.

Refs #41