### PR TITLE
feat(#27): Learner dashboard with progress aggregation

### DIFF
--- a/backend/src/controllers/dashboard-controller.ts
+++ b/backend/src/controllers/dashboard-controller.ts
@@ -1,0 +1,30 @@
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import type { DashboardService } from '../services/dashboard-service.js'
+import { logger } from '../utils/logger.js'
+
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  async getDashboard(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    const userId = request.user.id
+
+    const dashboard = await this.dashboardService.getDashboard(userId)
+
+    logger.info(
+      { requestId: request.id, userId },
+      'dashboard.fetched',
+    )
+
+    return reply.status(200).send({ data: dashboard, requestId: request.id })
+  }
+}

--- a/backend/src/dto/dashboard-dto.ts
+++ b/backend/src/dto/dashboard-dto.ts
@@ -1,0 +1,29 @@
+export interface DashboardInProgressDto {
+  courseId: number
+  title: string
+  thumbnailUrl: string | null
+  progress: {
+    completed: number
+    total: number
+    percentage: number
+  }
+}
+
+export interface DashboardCompletedDto {
+  courseId: number
+  title: string
+  completedAt: string
+}
+
+export interface DashboardCertificateDto {
+  courseId: number
+  title: string
+  certificateCode: string
+  issuedAt: string
+}
+
+export interface DashboardResponseDto {
+  inProgress: DashboardInProgressDto[]
+  completed: DashboardCompletedDto[]
+  certificates: DashboardCertificateDto[]
+}

--- a/backend/src/repositories/certificate-repository.ts
+++ b/backend/src/repositories/certificate-repository.ts
@@ -6,6 +6,7 @@ export interface ICertificateRepository {
   create(data: CreateCertificateData): Promise<Certificate>
   findById(id: number): Promise<Certificate | null>
   findByUserAndCourse(userId: number, courseId: number): Promise<Certificate | null>
+  findByUserId(userId: number): Promise<Certificate[]>
   findByCertificateCode(code: string): Promise<Certificate | null>
   delete(id: number): Promise<boolean>
 }
@@ -47,6 +48,14 @@ export class PrismaCertificateRepository implements ICertificateRepository {
     }
 
     return this.mapToCertificate(certificate)
+  }
+
+  async findByUserId(userId: number): Promise<Certificate[]> {
+    const certificates = await prisma.certificate.findMany({
+      where: { userId },
+    })
+
+    return certificates.map((c) => this.mapToCertificate(c))
   }
 
   async findByCertificateCode(code: string): Promise<Certificate | null> {

--- a/backend/src/routes/dashboard-routes.ts
+++ b/backend/src/routes/dashboard-routes.ts
@@ -1,0 +1,14 @@
+import type { FastifyInstance } from 'fastify'
+import type { DashboardController } from '../controllers/dashboard-controller.js'
+import { authMiddleware } from '../middlewares/auth.js'
+
+export async function dashboardRoutes(
+  app: FastifyInstance,
+  controller: DashboardController,
+): Promise<void> {
+  app.get(
+    '/me/dashboard',
+    { preHandler: [authMiddleware] },
+    controller.getDashboard.bind(controller),
+  )
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,14 +3,17 @@ import { authRoutes } from './auth-routes.js'
 import { courseRoutes } from './course-routes.js'
 import { enrollmentRoutes } from './enrollment-routes.js'
 import { lessonProgressRoutes } from './lesson-progress-routes.js'
+import { dashboardRoutes } from './dashboard-routes.js'
 import { AuthController } from '../controllers/auth-controller.js'
 import { CourseController } from '../controllers/course-controller.js'
 import { EnrollmentController } from '../controllers/enrollment-controller.js'
 import { LessonProgressController } from '../controllers/lesson-progress-controller.js'
+import { DashboardController } from '../controllers/dashboard-controller.js'
 import { AuthService } from '../services/auth-service.js'
 import { CourseService } from '../services/course-service.js'
 import { EnrollmentService } from '../services/enrollment-service.js'
 import { LessonProgressService } from '../services/lesson-progress-service.js'
+import { DashboardService } from '../services/dashboard-service.js'
 import { PrismaUserRepository } from '../repositories/user-repository.js'
 import { PrismaCourseRepository } from '../repositories/course-repository.js'
 import { PrismaLessonRepository } from '../repositories/lesson-repository.js'
@@ -24,6 +27,8 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   const lessonRepository = new PrismaLessonRepository()
   const enrollmentRepository = new PrismaEnrollmentRepository()
   const lessonProgressRepository = new PrismaLessonProgressRepository()
+  const { PrismaCertificateRepository } = await import('../repositories/certificate-repository.js')
+  const certificateRepository = new PrismaCertificateRepository()
 
   const authService = new AuthService(userRepository)
   const courseService = new CourseService(courseRepository, lessonRepository)
@@ -33,11 +38,19 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     lessonRepository,
     enrollmentRepository,
   )
+  const dashboardService = new DashboardService(
+    enrollmentRepository,
+    courseRepository,
+    lessonRepository,
+    lessonProgressRepository,
+    certificateRepository,
+  )
 
   const authController = new AuthController(authService)
   const courseController = new CourseController(courseService)
   const enrollmentController = new EnrollmentController(enrollmentService)
   const lessonProgressController = new LessonProgressController(lessonProgressService)
+  const dashboardController = new DashboardController(dashboardService)
 
   await app.register(
     async (api) => {
@@ -45,6 +58,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       await courseRoutes(api, courseController)
       await enrollmentRoutes(api, enrollmentController)
       await lessonProgressRoutes(api, lessonProgressController)
+      await dashboardRoutes(api, dashboardController)
     },
     { prefix: '/api/v1' },
   )

--- a/backend/src/services/dashboard-service.ts
+++ b/backend/src/services/dashboard-service.ts
@@ -1,0 +1,73 @@
+import type { IEnrollmentRepository } from '../repositories/enrollment-repository.js'
+import type { ICourseRepository } from '../repositories/course-repository.js'
+import type { ILessonRepository } from '../repositories/lesson-repository.js'
+import type { ILessonProgressRepository } from '../repositories/lesson-progress-repository.js'
+import type { ICertificateRepository } from '../repositories/certificate-repository.js'
+import type {
+  DashboardResponseDto,
+  DashboardInProgressDto,
+  DashboardCompletedDto,
+  DashboardCertificateDto,
+} from '../dto/dashboard-dto.js'
+
+export class DashboardService {
+  constructor(
+    private readonly enrollmentRepository: IEnrollmentRepository,
+    private readonly courseRepository: ICourseRepository,
+    private readonly lessonRepository: ILessonRepository,
+    private readonly lessonProgressRepository: ILessonProgressRepository,
+    private readonly certificateRepository: ICertificateRepository,
+  ) {}
+
+  async getDashboard(userId: number): Promise<DashboardResponseDto> {
+    const enrollments = await this.enrollmentRepository.findByUserId(userId)
+
+    const inProgress: DashboardInProgressDto[] = []
+    const completed: DashboardCompletedDto[] = []
+
+    for (const enrollment of enrollments) {
+      const course = await this.courseRepository.findById(enrollment.courseId)
+      if (!course) continue
+
+      if (enrollment.completedAt) {
+        completed.push({
+          courseId: course.id,
+          title: course.title,
+          completedAt: enrollment.completedAt.toISOString(),
+        })
+      } else {
+        const [allLessons, completedProgress] = await Promise.all([
+          this.lessonRepository.findByCourseId(course.id),
+          this.lessonProgressRepository.findByCourseProgress(userId, course.id),
+        ])
+
+        const total = allLessons.length
+        const completedCount = completedProgress.length
+        const percentage = total === 0 ? 0 : Math.floor((completedCount / total) * 100)
+
+        inProgress.push({
+          courseId: course.id,
+          title: course.title,
+          thumbnailUrl: course.thumbnailUrl,
+          progress: { completed: completedCount, total, percentage },
+        })
+      }
+    }
+
+    // Fetch certificates for completed courses
+    const userCertificates = await this.certificateRepository.findByUserId(userId)
+    const certificates: DashboardCertificateDto[] = []
+
+    for (const cert of userCertificates) {
+      const course = await this.courseRepository.findById(cert.courseId)
+      certificates.push({
+        courseId: cert.courseId,
+        title: course?.title ?? 'Unknown Course',
+        certificateCode: cert.certificateCode,
+        issuedAt: cert.issuedAt.toISOString(),
+      })
+    }
+
+    return { inProgress, completed, certificates }
+  }
+}

--- a/backend/test/unit/services/dashboard-service.spec.ts
+++ b/backend/test/unit/services/dashboard-service.spec.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DashboardService } from '../../../src/services/dashboard-service.js'
+import type { IEnrollmentRepository } from '../../../src/repositories/enrollment-repository.js'
+import type { ICourseRepository } from '../../../src/repositories/course-repository.js'
+import type { ILessonRepository } from '../../../src/repositories/lesson-repository.js'
+import type { ILessonProgressRepository } from '../../../src/repositories/lesson-progress-repository.js'
+import type { ICertificateRepository } from '../../../src/repositories/certificate-repository.js'
+
+function createMockEnrollmentRepository(): IEnrollmentRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByUserAndCourse: vi.fn(),
+    findByUserId: vi.fn(),
+    markCompleted: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function createMockCourseRepository(): ICourseRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByStatus: vi.fn(),
+    findPublished: vi.fn(),
+    countByStatus: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function createMockLessonRepository(): ILessonRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByCourseId: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function createMockLessonProgressRepository(): ILessonProgressRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByUserAndLesson: vi.fn(),
+    findByCourseProgress: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function createMockCertificateRepository(): ICertificateRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByUserAndCourse: vi.fn(),
+    findByUserId: vi.fn(),
+    findByCertificateCode: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+const now = new Date('2026-01-20T14:00:00.000Z')
+
+function createEnrollment(overrides = {}) {
+  return {
+    id: 1,
+    userId: 42,
+    courseId: 1,
+    startedAt: new Date('2026-01-15T10:00:00.000Z'),
+    completedAt: null as Date | null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function createCourse(overrides = {}) {
+  return {
+    id: 1,
+    title: 'Node.js Fundamentals',
+    description: 'Learn Node.js',
+    thumbnailUrl: 'https://example.com/thumb.jpg',
+    status: 'published' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function createLesson(id: number, courseId: number, position: number) {
+  return {
+    id,
+    courseId,
+    title: `Lesson ${position}`,
+    description: null,
+    youtubeUrl: `https://youtube.com/watch?v=test${id}`,
+    position,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+}
+
+function createProgress(id: number, userId: number, courseId: number, lessonId: number) {
+  return {
+    id,
+    userId,
+    courseId,
+    lessonId,
+    completedAt: now,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+}
+
+function createCertificate(overrides = {}) {
+  return {
+    id: 1,
+    userId: 42,
+    courseId: 2,
+    certificateCode: 'cert-uuid-1234',
+    issuedAt: now,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe('DashboardService', () => {
+  let service: DashboardService
+  let enrollmentRepo: IEnrollmentRepository
+  let courseRepo: ICourseRepository
+  let lessonRepo: ILessonRepository
+  let progressRepo: ILessonProgressRepository
+  let certificateRepo: ICertificateRepository
+
+  beforeEach(() => {
+    enrollmentRepo = createMockEnrollmentRepository()
+    courseRepo = createMockCourseRepository()
+    lessonRepo = createMockLessonRepository()
+    progressRepo = createMockLessonProgressRepository()
+    certificateRepo = createMockCertificateRepository()
+    service = new DashboardService(enrollmentRepo, courseRepo, lessonRepo, progressRepo, certificateRepo)
+  })
+
+  describe('getDashboard', () => {
+    it('AC-04: should return empty lists when learner has no enrollments', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([])
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([])
+
+      const result = await service.getDashboard(42)
+
+      expect(result).toEqual({ inProgress: [], completed: [], certificates: [] })
+    })
+
+    it('AC-01: should return in-progress courses with progress stats', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([
+        createEnrollment({ completedAt: null }),
+      ])
+      vi.mocked(courseRepo.findById).mockResolvedValue(createCourse())
+      vi.mocked(lessonRepo.findByCourseId).mockResolvedValue([
+        createLesson(1, 1, 1),
+        createLesson(2, 1, 2),
+        createLesson(3, 1, 3),
+        createLesson(4, 1, 4),
+        createLesson(5, 1, 5),
+        createLesson(6, 1, 6),
+        createLesson(7, 1, 7),
+        createLesson(8, 1, 8),
+        createLesson(9, 1, 9),
+        createLesson(10, 1, 10),
+      ])
+      vi.mocked(progressRepo.findByCourseProgress).mockResolvedValue([
+        createProgress(1, 42, 1, 1),
+        createProgress(2, 42, 1, 2),
+        createProgress(3, 42, 1, 3),
+      ])
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([])
+
+      const result = await service.getDashboard(42)
+
+      expect(result.inProgress).toHaveLength(1)
+      expect(result.inProgress[0]).toEqual({
+        courseId: 1,
+        title: 'Node.js Fundamentals',
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+        progress: { completed: 3, total: 10, percentage: 30 },
+      })
+      expect(result.completed).toHaveLength(0)
+    })
+
+    it('AC-02: should return completed courses with completedAt', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([
+        createEnrollment({ courseId: 2, completedAt: now }),
+      ])
+      vi.mocked(courseRepo.findById).mockResolvedValue(
+        createCourse({ id: 2, title: 'TypeScript Mastery' }),
+      )
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([])
+
+      const result = await service.getDashboard(42)
+
+      expect(result.completed).toHaveLength(1)
+      expect(result.completed[0]).toEqual({
+        courseId: 2,
+        title: 'TypeScript Mastery',
+        completedAt: now.toISOString(),
+      })
+      expect(result.inProgress).toHaveLength(0)
+    })
+
+    it('AC-03: should return certificates with course title and code', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([])
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([createCertificate()])
+      vi.mocked(courseRepo.findById).mockResolvedValue(
+        createCourse({ id: 2, title: 'TypeScript Mastery' }),
+      )
+
+      const result = await service.getDashboard(42)
+
+      expect(result.certificates).toHaveLength(1)
+      expect(result.certificates[0]).toEqual({
+        courseId: 2,
+        title: 'TypeScript Mastery',
+        certificateCode: 'cert-uuid-1234',
+        issuedAt: now.toISOString(),
+      })
+    })
+
+    it('should handle mixed state — in-progress, completed, and certificates', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([
+        createEnrollment({ id: 1, courseId: 1, completedAt: null }),
+        createEnrollment({ id: 2, courseId: 2, completedAt: now }),
+      ])
+      vi.mocked(courseRepo.findById)
+        .mockResolvedValueOnce(createCourse({ id: 1, title: 'Course In Progress' }))
+        .mockResolvedValueOnce(createCourse({ id: 2, title: 'Course Completed' }))
+        .mockResolvedValueOnce(createCourse({ id: 2, title: 'Course Completed' }))
+      vi.mocked(lessonRepo.findByCourseId).mockResolvedValue([createLesson(1, 1, 1)])
+      vi.mocked(progressRepo.findByCourseProgress).mockResolvedValue([])
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([
+        createCertificate({ courseId: 2 }),
+      ])
+
+      const result = await service.getDashboard(42)
+
+      expect(result.inProgress).toHaveLength(1)
+      expect(result.completed).toHaveLength(1)
+      expect(result.certificates).toHaveLength(1)
+    })
+
+    it('should calculate percentage as floor (no rounding up)', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([
+        createEnrollment({ completedAt: null }),
+      ])
+      vi.mocked(courseRepo.findById).mockResolvedValue(createCourse())
+      vi.mocked(lessonRepo.findByCourseId).mockResolvedValue([
+        createLesson(1, 1, 1),
+        createLesson(2, 1, 2),
+        createLesson(3, 1, 3),
+      ])
+      vi.mocked(progressRepo.findByCourseProgress).mockResolvedValue([
+        createProgress(1, 42, 1, 1),
+      ])
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([])
+
+      const result = await service.getDashboard(42)
+
+      // 1/3 = 33.33... → floor = 33
+      expect(result.inProgress[0]!.progress.percentage).toBe(33)
+    })
+
+    it('should return 0% progress when course has no lessons', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([
+        createEnrollment({ completedAt: null }),
+      ])
+      vi.mocked(courseRepo.findById).mockResolvedValue(createCourse())
+      vi.mocked(lessonRepo.findByCourseId).mockResolvedValue([])
+      vi.mocked(progressRepo.findByCourseProgress).mockResolvedValue([])
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([])
+
+      const result = await service.getDashboard(42)
+
+      expect(result.inProgress[0]!.progress).toEqual({
+        completed: 0,
+        total: 0,
+        percentage: 0,
+      })
+    })
+
+    it('should skip enrollments for courses that no longer exist', async () => {
+      vi.mocked(enrollmentRepo.findByUserId).mockResolvedValue([
+        createEnrollment({ courseId: 999 }),
+      ])
+      vi.mocked(courseRepo.findById).mockResolvedValue(null)
+      vi.mocked(certificateRepo.findByUserId).mockResolvedValue([])
+
+      const result = await service.getDashboard(42)
+
+      expect(result.inProgress).toHaveLength(0)
+      expect(result.completed).toHaveLength(0)
+    })
+  })
+})

--- a/integration-tests/test/api/dashboard.spec.ts
+++ b/integration-tests/test/api/dashboard.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Dashboard integration tests.
+ *
+ * Tests: GET /api/v1/me/dashboard
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { get, post } from '../../helpers/request.js'
+import { setupDb, teardownDb, truncateAll, getTestPrisma } from '../../helpers/db.js'
+
+const shouldRun = process.env['RUN_INTEGRATION_TESTS'] === 'true'
+const describeOrSkip = shouldRun ? describe : describe.skip
+
+interface DashboardResponse {
+  data: {
+    inProgress: Array<{
+      courseId: number
+      title: string
+      thumbnailUrl: string | null
+      progress: { completed: number; total: number; percentage: number }
+    }>
+    completed: Array<{
+      courseId: number
+      title: string
+      completedAt: string
+    }>
+    certificates: Array<{
+      courseId: number
+      title: string
+      certificateCode: string
+      issuedAt: string
+    }>
+  }
+  requestId: string
+}
+
+interface ErrorResponse {
+  error: {
+    code: string
+    message: string
+    requestId: string
+  }
+}
+
+interface LoginResponse {
+  data: {
+    accessToken: string
+    expiresIn: string
+    user: { id: number; name: string; email: string; role: string }
+  }
+  requestId: string
+}
+
+async function seedCourseWithLessons(
+  title = 'Test Course',
+  lessonCount = 2,
+): Promise<{ courseId: number; lessonIds: number[] }> {
+  const prisma = getTestPrisma()
+
+  await prisma.$executeRaw`
+    INSERT INTO courses (title, description, status, created_at, updated_at)
+    VALUES (${title}, 'A test course', 'published', NOW(), NOW())
+  `
+  const courseRows = await prisma.$queryRaw`SELECT LAST_INSERT_ID() as id` as Array<{ id: bigint }>
+  const courseId = Number(courseRows[0]!.id)
+
+  const lessonIds: number[] = []
+  for (let i = 1; i <= lessonCount; i++) {
+    await prisma.$executeRaw`
+      INSERT INTO lessons (course_id, title, youtube_url, position, created_at, updated_at)
+      VALUES (${courseId}, ${`Lesson ${i}`}, ${`https://youtube.com/watch?v=test${i}`}, ${i}, NOW(), NOW())
+    `
+    const lessonRows = await prisma.$queryRaw`SELECT LAST_INSERT_ID() as id` as Array<{ id: bigint }>
+    lessonIds.push(Number(lessonRows[0]!.id))
+  }
+
+  return { courseId, lessonIds }
+}
+
+async function registerAndLogin(
+  email = 'learner@example.com',
+  password = 'securepassword123',
+): Promise<{ token: string; userId: number }> {
+  await post('/api/v1/auth/register', { name: 'Test Learner', email, password })
+  const loginRes = await post<LoginResponse>('/api/v1/auth/login', { email, password })
+  return {
+    token: loginRes.body.data.accessToken,
+    userId: loginRes.body.data.user.id,
+  }
+}
+
+async function enrollUser(courseId: number, token: string): Promise<void> {
+  await post(`/api/v1/courses/${courseId}/enrollments`, {}, { Authorization: `Bearer ${token}` })
+}
+
+async function completeAllLessons(courseId: number, lessonIds: number[], token: string): Promise<void> {
+  for (const lessonId of lessonIds) {
+    await post(
+      `/api/v1/courses/${courseId}/lessons/${lessonId}/progress`,
+      {},
+      { Authorization: `Bearer ${token}` },
+    )
+  }
+}
+
+describeOrSkip('Dashboard Endpoints', () => {
+  beforeAll(async () => {
+    await setupDb()
+  })
+
+  beforeEach(async () => {
+    await truncateAll()
+  })
+
+  afterAll(async () => {
+    await teardownDb()
+  })
+
+  describe('GET /api/v1/me/dashboard', () => {
+    it('AC-01: should return in-progress courses with progress stats', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons('Node.js Fundamentals', 3)
+      const { token } = await registerAndLogin()
+      await enrollUser(courseId, token)
+
+      // Complete 1 of 3 lessons
+      await post(
+        `/api/v1/courses/${courseId}/lessons/${lessonIds[0]}/progress`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      const res = await get<DashboardResponse>(
+        '/api/v1/me/dashboard',
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.inProgress).toHaveLength(1)
+      expect(res.body.data.inProgress[0]).toMatchObject({
+        courseId,
+        title: 'Node.js Fundamentals',
+        progress: { completed: 1, total: 3, percentage: 33 },
+      })
+    })
+
+    it('AC-02: should return completed courses with completedAt', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons('TypeScript Mastery', 2)
+      const { token } = await registerAndLogin()
+      await enrollUser(courseId, token)
+      await completeAllLessons(courseId, lessonIds, token)
+
+      const res = await get<DashboardResponse>(
+        '/api/v1/me/dashboard',
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.completed).toHaveLength(1)
+      expect(res.body.data.completed[0]!.courseId).toBe(courseId)
+      expect(res.body.data.completed[0]!.title).toBe('TypeScript Mastery')
+      expect(res.body.data.completed[0]!.completedAt).toBeTypeOf('string')
+      expect(res.body.data.inProgress).toHaveLength(0)
+    })
+
+    it('AC-03: should return certificates for completed courses', async () => {
+      const { courseId, lessonIds } = await seedCourseWithLessons('Cert Course', 1)
+      const { token } = await registerAndLogin()
+      await enrollUser(courseId, token)
+      await completeAllLessons(courseId, lessonIds, token)
+
+      // Generate certificate
+      await post(
+        `/api/v1/courses/${courseId}/certificate`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      const res = await get<DashboardResponse>(
+        '/api/v1/me/dashboard',
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.certificates).toHaveLength(1)
+      expect(res.body.data.certificates[0]!.courseId).toBe(courseId)
+      expect(res.body.data.certificates[0]!.certificateCode).toBeTypeOf('string')
+      expect(res.body.data.certificates[0]!.issuedAt).toBeTypeOf('string')
+    })
+
+    it('AC-04: should return empty lists when learner has no enrollments', async () => {
+      const { token } = await registerAndLogin()
+
+      const res = await get<DashboardResponse>(
+        '/api/v1/me/dashboard',
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data).toEqual({
+        inProgress: [],
+        completed: [],
+        certificates: [],
+      })
+    })
+
+    it('AC-05: should return 401 when no auth token is provided', async () => {
+      const res = await get<ErrorResponse>('/api/v1/me/dashboard')
+
+      expect(res.status).toBe(401)
+      expect(res.body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('should include requestId in response', async () => {
+      const { token } = await registerAndLogin()
+
+      const res = await get<DashboardResponse>(
+        '/api/v1/me/dashboard',
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.body.requestId).toBeTypeOf('string')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #27 — **Learner Dashboard**.

Adds `GET /api/v1/me/dashboard` that returns aggregated data about the learner's in-progress courses, completed courses, and certificates.

## Changes

| File | Action | Purpose |
|------|--------|---------|
| `backend/src/dto/dashboard-dto.ts` | create | Response type interfaces |
| `backend/src/services/dashboard-service.ts` | create | Aggregation from 5 repositories |
| `backend/src/controllers/dashboard-controller.ts` | create | HTTP handler with auth guard |
| `backend/src/routes/dashboard-routes.ts` | create | Route registration |
| `backend/src/repositories/certificate-repository.ts` | modify | Added `findByUserId()` |
| `backend/src/routes/index.ts` | modify | DI wiring |
| `backend/test/unit/services/dashboard-service.spec.ts` | create | 8 unit tests |
| `integration-tests/test/api/dashboard.spec.ts` | create | 6 integration tests |

## Acceptance Criteria

- ✅ AC-01: In-progress courses with progress stats (completed/total/percentage)
- ✅ AC-02: Completed courses with completedAt
- ✅ AC-03: Certificates with certificateCode and issuedAt
- ✅ AC-04: Empty lists when no enrollments
- ✅ AC-05: No auth → 401 UNAUTHORIZED

## Tests
- **64 unit tests pass** (8 new + 56 existing)
- **6 integration tests** ready (`RUN_INTEGRATION_TESTS=true`)

Closes #27