### PR TITLE
feat(#30): Admin CRUD courses + admin guard middleware

### DIFF
--- a/backend/src/controllers/admin-course-controller.ts
+++ b/backend/src/controllers/admin-course-controller.ts
@@ -1,0 +1,157 @@
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import type { AdminCourseService } from '../services/admin-course-service.js'
+import {
+  AdminCourseIdParamSchema,
+  CreateCourseBodySchema,
+  UpdateCourseBodySchema,
+} from '../dto/admin-course-dto.js'
+import type { AdminCourseResponseDto } from '../dto/admin-course-dto.js'
+import { logger } from '../utils/logger.js'
+
+export class AdminCourseController {
+  constructor(private readonly adminCourseService: AdminCourseService) {}
+
+  async create(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const body = CreateCourseBodySchema.parse(request.body)
+
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    const course = await this.adminCourseService.create(body)
+
+    const data: AdminCourseResponseDto = this.formatCourse(course)
+
+    logger.info(
+      { requestId: request.id, userId: request.user.id, courseId: course.id },
+      'admin.course.created',
+    )
+
+    return reply.status(201).send({ data, requestId: request.id })
+  }
+
+  async update(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const params = AdminCourseIdParamSchema.parse(request.params)
+    const body = UpdateCourseBodySchema.parse(request.body)
+
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    const course = await this.adminCourseService.update(params.id, body)
+
+    const data: AdminCourseResponseDto = this.formatCourse(course)
+
+    logger.info(
+      { requestId: request.id, userId: request.user.id, courseId: course.id },
+      'admin.course.updated',
+    )
+
+    return reply.status(200).send({ data, requestId: request.id })
+  }
+
+  async publish(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const params = AdminCourseIdParamSchema.parse(request.params)
+
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    const course = await this.adminCourseService.publish(params.id)
+
+    const data: AdminCourseResponseDto = this.formatCourse(course)
+
+    logger.info(
+      { requestId: request.id, userId: request.user.id, courseId: course.id },
+      'admin.course.published',
+    )
+
+    return reply.status(200).send({ data, requestId: request.id })
+  }
+
+  async unpublish(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const params = AdminCourseIdParamSchema.parse(request.params)
+
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    const course = await this.adminCourseService.unpublish(params.id)
+
+    const data: AdminCourseResponseDto = this.formatCourse(course)
+
+    logger.info(
+      { requestId: request.id, userId: request.user.id, courseId: course.id },
+      'admin.course.unpublished',
+    )
+
+    return reply.status(200).send({ data, requestId: request.id })
+  }
+
+  async delete(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const params = AdminCourseIdParamSchema.parse(request.params)
+
+    if (!request.user) {
+      return reply.status(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Missing or invalid authentication token',
+          requestId: request.id,
+        },
+      })
+    }
+
+    await this.adminCourseService.delete(params.id)
+
+    logger.info(
+      { requestId: request.id, userId: request.user.id, courseId: params.id },
+      'admin.course.deleted',
+    )
+
+    return reply.status(204).send()
+  }
+
+  private formatCourse(course: {
+    id: number
+    title: string
+    description: string
+    thumbnailUrl: string | null
+    status: string
+    createdAt: Date
+    updatedAt: Date
+  }): AdminCourseResponseDto {
+    return {
+      id: course.id,
+      title: course.title,
+      description: course.description,
+      thumbnailUrl: course.thumbnailUrl,
+      status: course.status,
+      createdAt: course.createdAt.toISOString(),
+      updatedAt: course.updatedAt.toISOString(),
+    }
+  }
+}

--- a/backend/src/dto/admin-course-dto.ts
+++ b/backend/src/dto/admin-course-dto.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+// ── Path Params ───────────────────────────────────────────────
+
+export const AdminCourseIdParamSchema = z.object({
+  id: z.coerce.number().int().min(1),
+})
+
+export type AdminCourseIdParamDto = z.infer<typeof AdminCourseIdParamSchema>
+
+// ── Request Bodies ────────────────────────────────────────────
+
+export const CreateCourseBodySchema = z.object({
+  title: z.string().min(1).max(180),
+  description: z.string().min(1),
+  thumbnailUrl: z.string().url().optional(),
+})
+
+export type CreateCourseBodyDto = z.infer<typeof CreateCourseBodySchema>
+
+export const UpdateCourseBodySchema = z.object({
+  title: z.string().min(1).max(180).optional(),
+  description: z.string().min(1).optional(),
+  thumbnailUrl: z.string().url().nullish(),
+})
+
+export type UpdateCourseBodyDto = z.infer<typeof UpdateCourseBodySchema>
+
+// ── Response DTOs ─────────────────────────────────────────────
+
+export interface AdminCourseResponseDto {
+  id: number
+  title: string
+  description: string
+  thumbnailUrl: string | null
+  status: string
+  createdAt: string
+  updatedAt: string
+}

--- a/backend/src/middlewares/admin-guard.ts
+++ b/backend/src/middlewares/admin-guard.ts
@@ -1,0 +1,43 @@
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import { logger } from '../utils/logger.js'
+
+/**
+ * Admin guard middleware.
+ *
+ * Must be used AFTER authMiddleware so that `request.user` is populated.
+ * Returns 403 FORBIDDEN when the authenticated user is not an admin.
+ * Defensively returns 401 if `request.user` is missing (auth middleware
+ * should have already rejected, but be safe).
+ */
+export async function adminGuardMiddleware(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  if (!request.user) {
+    logger.warn(
+      { requestId: request.id },
+      'Admin guard: request.user not set (auth middleware may not have run)',
+    )
+    return reply.status(401).send({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Missing or invalid authentication token',
+        requestId: request.id,
+      },
+    })
+  }
+
+  if (request.user.role !== 'admin') {
+    logger.warn(
+      { requestId: request.id, userId: request.user.id, role: request.user.role },
+      'Admin guard: non-admin user attempted admin action',
+    )
+    return reply.status(403).send({
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Forbidden',
+        requestId: request.id,
+      },
+    })
+  }
+}

--- a/backend/src/routes/admin-course-routes.ts
+++ b/backend/src/routes/admin-course-routes.ts
@@ -1,0 +1,41 @@
+import type { FastifyInstance } from 'fastify'
+import type { AdminCourseController } from '../controllers/admin-course-controller.js'
+import { authMiddleware } from '../middlewares/auth.js'
+import { adminGuardMiddleware } from '../middlewares/admin-guard.js'
+
+export async function adminCourseRoutes(
+  app: FastifyInstance,
+  controller: AdminCourseController,
+): Promise<void> {
+  const preHandler = [authMiddleware, adminGuardMiddleware]
+
+  app.post(
+    '/courses',
+    { preHandler },
+    (request, reply) => controller.create(request, reply),
+  )
+
+  app.put(
+    '/courses/:id',
+    { preHandler },
+    (request, reply) => controller.update(request, reply),
+  )
+
+  app.patch(
+    '/courses/:id/publish',
+    { preHandler },
+    (request, reply) => controller.publish(request, reply),
+  )
+
+  app.patch(
+    '/courses/:id/unpublish',
+    { preHandler },
+    (request, reply) => controller.unpublish(request, reply),
+  )
+
+  app.delete(
+    '/courses/:id',
+    { preHandler },
+    (request, reply) => controller.delete(request, reply),
+  )
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,14 +1,17 @@
 import type { FastifyInstance } from 'fastify'
 import { authRoutes } from './auth-routes.js'
 import { courseRoutes } from './course-routes.js'
+import { adminCourseRoutes } from './admin-course-routes.js'
 import { enrollmentRoutes } from './enrollment-routes.js'
 import { lessonProgressRoutes } from './lesson-progress-routes.js'
 import { AuthController } from '../controllers/auth-controller.js'
 import { CourseController } from '../controllers/course-controller.js'
+import { AdminCourseController } from '../controllers/admin-course-controller.js'
 import { EnrollmentController } from '../controllers/enrollment-controller.js'
 import { LessonProgressController } from '../controllers/lesson-progress-controller.js'
 import { AuthService } from '../services/auth-service.js'
 import { CourseService } from '../services/course-service.js'
+import { AdminCourseService } from '../services/admin-course-service.js'
 import { EnrollmentService } from '../services/enrollment-service.js'
 import { LessonProgressService } from '../services/lesson-progress-service.js'
 import { PrismaUserRepository } from '../repositories/user-repository.js'
@@ -27,6 +30,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
 
   const authService = new AuthService(userRepository)
   const courseService = new CourseService(courseRepository, lessonRepository)
+  const adminCourseService = new AdminCourseService(courseRepository, lessonRepository)
   const enrollmentService = new EnrollmentService(enrollmentRepository, courseRepository)
   const lessonProgressService = new LessonProgressService(
     lessonProgressRepository,
@@ -36,6 +40,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
 
   const authController = new AuthController(authService)
   const courseController = new CourseController(courseService)
+  const adminCourseController = new AdminCourseController(adminCourseService)
   const enrollmentController = new EnrollmentController(enrollmentService)
   const lessonProgressController = new LessonProgressController(lessonProgressService)
 
@@ -43,6 +48,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     async (api) => {
       await authRoutes(api, authController)
       await courseRoutes(api, courseController)
+      await adminCourseRoutes(api, adminCourseController)
       await enrollmentRoutes(api, enrollmentController)
       await lessonProgressRoutes(api, lessonProgressController)
     },

--- a/backend/src/services/admin-course-service.ts
+++ b/backend/src/services/admin-course-service.ts
@@ -1,0 +1,106 @@
+import type { Course, CreateCourseData } from '../models/course.js'
+import type { ICourseRepository } from '../repositories/course-repository.js'
+import type { ILessonRepository } from '../repositories/lesson-repository.js'
+import { NotFoundError, BadRequestError } from '../models/errors.js'
+
+export interface CreateCourseInput {
+  title: string
+  description: string
+  thumbnailUrl?: string
+}
+
+export interface UpdateCourseInput {
+  title?: string
+  description?: string
+  thumbnailUrl?: string | null
+}
+
+export class AdminCourseService {
+  constructor(
+    private readonly courseRepository: ICourseRepository,
+    private readonly lessonRepository: ILessonRepository,
+  ) {}
+
+  async create(data: CreateCourseInput): Promise<Course> {
+    const courseData: CreateCourseData = {
+      title: data.title,
+      description: data.description,
+      thumbnailUrl: data.thumbnailUrl ?? null,
+      status: 'draft',
+    }
+
+    return this.courseRepository.create(courseData)
+  }
+
+  async update(id: number, data: UpdateCourseInput): Promise<Course> {
+    const updateData: Partial<CreateCourseData> = {}
+
+    if (data.title !== undefined) updateData.title = data.title
+    if (data.description !== undefined) updateData.description = data.description
+    if (data.thumbnailUrl !== undefined) updateData.thumbnailUrl = data.thumbnailUrl
+
+    const course = await this.courseRepository.update(id, updateData)
+
+    if (!course) {
+      throw new NotFoundError('Course not found')
+    }
+
+    return course
+  }
+
+  async publish(id: number): Promise<Course> {
+    const course = await this.courseRepository.findById(id)
+
+    if (!course) {
+      throw new NotFoundError('Course not found')
+    }
+
+    // Validate prerequisites
+    const errors: string[] = []
+
+    if (!course.title || course.title.trim() === '') {
+      errors.push('Course title must not be empty')
+    }
+
+    if (!course.description || course.description.trim() === '') {
+      errors.push('Course description must not be empty')
+    }
+
+    const lessons = await this.lessonRepository.findByCourseId(id)
+    if (lessons.length === 0) {
+      errors.push('Course must have at least one lesson')
+    }
+
+    if (errors.length > 0) {
+      throw new BadRequestError(
+        `Cannot publish course: ${errors.join('; ')}`,
+      )
+    }
+
+    const updated = await this.courseRepository.update(id, { status: 'published' })
+
+    if (!updated) {
+      throw new NotFoundError('Course not found')
+    }
+
+    return updated
+  }
+
+  async unpublish(id: number): Promise<Course> {
+    const updated = await this.courseRepository.update(id, { status: 'unpublished' })
+
+    if (!updated) {
+      throw new NotFoundError('Course not found')
+    }
+
+    return updated
+  }
+
+  async delete(id: number): Promise<void> {
+    const deleted = await this.courseRepository.delete(id)
+
+    if (!deleted) {
+      throw new NotFoundError('Course not found')
+    }
+  }
+}

--- a/backend/test/unit/middlewares/admin-guard.spec.ts
+++ b/backend/test/unit/middlewares/admin-guard.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import { adminGuardMiddleware } from '../../../src/middlewares/admin-guard.js'
+
+// Mock logger
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+function createMockRequest(overrides: Partial<FastifyRequest> = {}): FastifyRequest {
+  return {
+    id: 'req-test-123',
+    headers: {},
+    ...overrides,
+  } as unknown as FastifyRequest
+}
+
+function createMockReply(): FastifyReply {
+  const reply = {
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+  }
+  return reply as unknown as FastifyReply
+}
+
+describe('adminGuardMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should allow admin user to proceed', async () => {
+    const request = createMockRequest()
+    request.user = { id: 1, email: 'admin@example.com', role: 'admin' }
+    const reply = createMockReply()
+
+    await adminGuardMiddleware(request, reply)
+
+    expect(reply.status).not.toHaveBeenCalled()
+    expect(reply.send).not.toHaveBeenCalled()
+  })
+
+  it('should return 403 for learner user', async () => {
+    const request = createMockRequest()
+    request.user = { id: 2, email: 'learner@example.com', role: 'learner' }
+    const reply = createMockReply()
+
+    await adminGuardMiddleware(request, reply)
+
+    expect(reply.status).toHaveBeenCalledWith(403)
+    expect(reply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'FORBIDDEN',
+          requestId: 'req-test-123',
+        }),
+      }),
+    )
+  })
+
+  it('should return 401 if request.user is not set', async () => {
+    const request = createMockRequest()
+    // request.user is undefined
+    const reply = createMockReply()
+
+    await adminGuardMiddleware(request, reply)
+
+    expect(reply.status).toHaveBeenCalledWith(401)
+    expect(reply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'UNAUTHORIZED',
+          requestId: 'req-test-123',
+        }),
+      }),
+    )
+  })
+
+  it('should return 403 for any non-admin role', async () => {
+    const request = createMockRequest()
+    request.user = { id: 3, email: 'mod@example.com', role: 'moderator' }
+    const reply = createMockReply()
+
+    await adminGuardMiddleware(request, reply)
+
+    expect(reply.status).toHaveBeenCalledWith(403)
+  })
+})

--- a/backend/test/unit/services/admin-course-service.spec.ts
+++ b/backend/test/unit/services/admin-course-service.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AdminCourseService } from '../../../src/services/admin-course-service.js'
+import type { ICourseRepository } from '../../../src/repositories/course-repository.js'
+import type { ILessonRepository } from '../../../src/repositories/lesson-repository.js'
+import { createCourseFactory, createLessonFactory } from '../../helpers/factories.js'
+import { NotFoundError, BadRequestError } from '../../../src/models/errors.js'
+
+function createMockCourseRepository(): ICourseRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByStatus: vi.fn(),
+    findPublished: vi.fn(),
+    countByStatus: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+function createMockLessonRepository(): ILessonRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByCourseId: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+describe('AdminCourseService', () => {
+  let service: AdminCourseService
+  let mockCourseRepo: ICourseRepository
+  let mockLessonRepo: ILessonRepository
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCourseRepo = createMockCourseRepository()
+    mockLessonRepo = createMockLessonRepository()
+    service = new AdminCourseService(mockCourseRepo, mockLessonRepo)
+  })
+
+  // ────────────────────────────────────────
+  // create
+  // ────────────────────────────────────────
+  describe('create', () => {
+    it('should create a course with status draft', async () => {
+      const created = createCourseFactory({ id: 1, title: 'New Course', status: 'draft' })
+      vi.mocked(mockCourseRepo.create).mockResolvedValue(created)
+
+      const result = await service.create({
+        title: 'New Course',
+        description: 'A new course',
+      })
+
+      expect(result).toEqual(created)
+      expect(mockCourseRepo.create).toHaveBeenCalledWith({
+        title: 'New Course',
+        description: 'A new course',
+        thumbnailUrl: null,
+        status: 'draft',
+      })
+    })
+
+    it('should pass thumbnailUrl when provided', async () => {
+      const created = createCourseFactory({ id: 2, thumbnailUrl: 'https://img.com/thumb.jpg' })
+      vi.mocked(mockCourseRepo.create).mockResolvedValue(created)
+
+      await service.create({
+        title: 'With Thumb',
+        description: 'Has thumbnail',
+        thumbnailUrl: 'https://img.com/thumb.jpg',
+      })
+
+      expect(mockCourseRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ thumbnailUrl: 'https://img.com/thumb.jpg' }),
+      )
+    })
+  })
+
+  // ────────────────────────────────────────
+  // update
+  // ────────────────────────────────────────
+  describe('update', () => {
+    it('should update course and return updated data', async () => {
+      const updated = createCourseFactory({ id: 1, title: 'Updated Title' })
+      vi.mocked(mockCourseRepo.update).mockResolvedValue(updated)
+
+      const result = await service.update(1, { title: 'Updated Title' })
+
+      expect(result).toEqual(updated)
+      expect(mockCourseRepo.update).toHaveBeenCalledWith(1, { title: 'Updated Title' })
+    })
+
+    it('should throw NotFoundError when course does not exist', async () => {
+      vi.mocked(mockCourseRepo.update).mockResolvedValue(null)
+
+      await expect(service.update(999, { title: 'X' })).rejects.toThrow(NotFoundError)
+      await expect(service.update(999, { title: 'X' })).rejects.toThrow('Course not found')
+    })
+  })
+
+  // ────────────────────────────────────────
+  // publish
+  // ────────────────────────────────────────
+  describe('publish', () => {
+    it('should publish course when all prerequisites are met', async () => {
+      const course = createCourseFactory({ id: 1, title: 'Course', description: 'Desc', status: 'draft' })
+      const lessons = [createLessonFactory({ courseId: 1 })]
+      const published = { ...course, status: 'published' as const }
+
+      vi.mocked(mockCourseRepo.findById).mockResolvedValue(course)
+      vi.mocked(mockLessonRepo.findByCourseId).mockResolvedValue(lessons)
+      vi.mocked(mockCourseRepo.update).mockResolvedValue(published)
+
+      const result = await service.publish(1)
+
+      expect(result.status).toBe('published')
+      expect(mockCourseRepo.update).toHaveBeenCalledWith(1, { status: 'published' })
+    })
+
+    it('should throw BadRequestError when course has no lessons', async () => {
+      const course = createCourseFactory({ id: 1, title: 'Course', description: 'Desc', status: 'draft' })
+
+      vi.mocked(mockCourseRepo.findById).mockResolvedValue(course)
+      vi.mocked(mockLessonRepo.findByCourseId).mockResolvedValue([])
+
+      await expect(service.publish(1)).rejects.toThrow(BadRequestError)
+      await expect(service.publish(1)).rejects.toThrow('Cannot publish course')
+    })
+
+    it('should throw NotFoundError when course does not exist', async () => {
+      vi.mocked(mockCourseRepo.findById).mockResolvedValue(null)
+
+      await expect(service.publish(999)).rejects.toThrow(NotFoundError)
+      await expect(service.publish(999)).rejects.toThrow('Course not found')
+    })
+  })
+
+  // ────────────────────────────────────────
+  // unpublish
+  // ────────────────────────────────────────
+  describe('unpublish', () => {
+    it('should unpublish course successfully', async () => {
+      const unpublished = createCourseFactory({ id: 1, status: 'unpublished' })
+      vi.mocked(mockCourseRepo.update).mockResolvedValue(unpublished)
+
+      const result = await service.unpublish(1)
+
+      expect(result.status).toBe('unpublished')
+      expect(mockCourseRepo.update).toHaveBeenCalledWith(1, { status: 'unpublished' })
+    })
+
+    it('should throw NotFoundError when course does not exist', async () => {
+      vi.mocked(mockCourseRepo.update).mockResolvedValue(null)
+
+      await expect(service.unpublish(999)).rejects.toThrow(NotFoundError)
+      await expect(service.unpublish(999)).rejects.toThrow('Course not found')
+    })
+  })
+
+  // ────────────────────────────────────────
+  // delete
+  // ────────────────────────────────────────
+  describe('delete', () => {
+    it('should delete course successfully', async () => {
+      vi.mocked(mockCourseRepo.delete).mockResolvedValue(true)
+
+      await expect(service.delete(1)).resolves.toBeUndefined()
+      expect(mockCourseRepo.delete).toHaveBeenCalledWith(1)
+    })
+
+    it('should throw NotFoundError when course does not exist', async () => {
+      vi.mocked(mockCourseRepo.delete).mockResolvedValue(false)
+
+      await expect(service.delete(999)).rejects.toThrow(NotFoundError)
+      await expect(service.delete(999)).rejects.toThrow('Course not found')
+    })
+  })
+})

--- a/integration-tests/test/api/admin-courses.spec.ts
+++ b/integration-tests/test/api/admin-courses.spec.ts
@@ -1,0 +1,565 @@
+/**
+ * Admin CRUD Courses integration tests.
+ *
+ * Tests: POST /api/v1/courses, PUT /api/v1/courses/:id,
+ *        PATCH /api/v1/courses/:id/publish, PATCH /api/v1/courses/:id/unpublish,
+ *        DELETE /api/v1/courses/:id
+ *
+ * Requires:
+ *   - A running backend instance (BACKEND_URL, default: http://localhost:3001)
+ *   - A clean test database
+ *   - RUN_INTEGRATION_TESTS=true
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { post, get } from '../../helpers/request.js'
+import { setupDb, teardownDb, truncateAll, getTestPrisma } from '../../helpers/db.js'
+
+const shouldRun = process.env['RUN_INTEGRATION_TESTS'] === 'true'
+const describeOrSkip = shouldRun ? describe : describe.skip
+
+const BASE_URL = process.env['BACKEND_URL'] ?? 'http://localhost:3001'
+
+// ── Response type interfaces ─────────────────────────────────
+
+interface CourseItem {
+  id: number
+  title: string
+  description: string
+  thumbnailUrl: string | null
+  status: string
+  createdAt: string
+  updatedAt: string
+}
+
+interface CourseResponse {
+  data: CourseItem
+  requestId: string
+}
+
+interface ErrorResponse {
+  error: {
+    code: string
+    message: string
+    details?: Array<{ field: string; message: string }>
+    requestId: string
+  }
+}
+
+interface LoginResponse {
+  data: {
+    accessToken: string
+    expiresIn: string
+    user: { id: number; name: string; email: string; role: string }
+  }
+  requestId: string
+}
+
+// ── HTTP helpers for PUT, PATCH, DELETE ───────────────────────
+
+interface TestResponse<T = unknown> {
+  status: number
+  body: T
+  requestId: string | null
+  headers: Headers
+}
+
+async function put<T = unknown>(
+  path: string,
+  data: unknown,
+  headers: Record<string, string> = {},
+): Promise<TestResponse<T>> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(data),
+  })
+  let body: T
+  if (res.status === 204) {
+    body = undefined as unknown as T
+  } else {
+    body = (await res.json()) as T
+  }
+  return {
+    status: res.status,
+    body,
+    requestId: res.headers.get('x-request-id'),
+    headers: res.headers,
+  }
+}
+
+async function patch<T = unknown>(
+  path: string,
+  data: unknown = {},
+  headers: Record<string, string> = {},
+): Promise<TestResponse<T>> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(data),
+  })
+  let body: T
+  if (res.status === 204) {
+    body = undefined as unknown as T
+  } else {
+    body = (await res.json()) as T
+  }
+  return {
+    status: res.status,
+    body,
+    requestId: res.headers.get('x-request-id'),
+    headers: res.headers,
+  }
+}
+
+async function del<T = unknown>(
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<TestResponse<T>> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+  let body: T
+  if (res.status === 204) {
+    body = undefined as unknown as T
+  } else {
+    body = (await res.json()) as T
+  }
+  return {
+    status: res.status,
+    body,
+    requestId: res.headers.get('x-request-id'),
+    headers: res.headers,
+  }
+}
+
+// ── Seed helpers ─────────────────────────────────────────────
+
+/**
+ * Register a user via API, upgrade to admin via SQL, then login.
+ * Returns the admin access token and userId.
+ */
+async function seedAdminAndLogin(
+  email = 'admin@example.com',
+  password = 'adminpassword123',
+): Promise<{ token: string; userId: number }> {
+  // Register via API (creates a learner)
+  await post('/api/v1/auth/register', {
+    name: 'Admin User',
+    email,
+    password,
+  })
+
+  // Upgrade to admin via raw SQL
+  const prisma = getTestPrisma()
+  await prisma.$executeRaw`UPDATE users SET role = 'admin' WHERE email = ${email}`
+
+  // Login to get JWT with role=admin
+  const loginRes = await post<LoginResponse>('/api/v1/auth/login', {
+    email,
+    password,
+  })
+
+  return {
+    token: loginRes.body.data.accessToken,
+    userId: loginRes.body.data.user.id,
+  }
+}
+
+/**
+ * Register + login a learner user and return their access token.
+ */
+async function registerAndLogin(
+  email = 'learner@example.com',
+  password = 'securepassword123',
+): Promise<{ token: string; userId: number }> {
+  await post('/api/v1/auth/register', {
+    name: 'Test Learner',
+    email,
+    password,
+  })
+
+  const loginRes = await post<LoginResponse>('/api/v1/auth/login', {
+    email,
+    password,
+  })
+
+  return {
+    token: loginRes.body.data.accessToken,
+    userId: loginRes.body.data.user.id,
+  }
+}
+
+/**
+ * Seed a course directly in the DB. Returns the course id.
+ */
+async function seedCourse(overrides: {
+  title?: string
+  description?: string
+  thumbnailUrl?: string | null
+  status?: string
+} = {}): Promise<number> {
+  const prisma = getTestPrisma()
+  const title = overrides.title ?? 'Test Course'
+  const description = overrides.description ?? 'A test course'
+  const thumbnailUrl = overrides.thumbnailUrl ?? null
+  const status = overrides.status ?? 'draft'
+
+  await prisma.$executeRaw`
+    INSERT INTO courses (title, description, thumbnail_url, status, created_at, updated_at)
+    VALUES (${title}, ${description}, ${thumbnailUrl}, ${status}, NOW(), NOW())
+  `
+
+  const rows = await prisma.$queryRaw`SELECT LAST_INSERT_ID() as id` as Array<{ id: bigint }>
+  return Number(rows[0]!.id)
+}
+
+/**
+ * Seed a lesson directly in the DB. Returns the lesson id.
+ */
+async function seedLesson(overrides: {
+  courseId: number
+  title?: string
+  description?: string | null
+  youtubeUrl?: string
+  position: number
+}): Promise<number> {
+  const prisma = getTestPrisma()
+  const title = overrides.title ?? `Lesson ${overrides.position}`
+  const description = overrides.description ?? null
+  const youtubeUrl = overrides.youtubeUrl ?? 'https://youtube.com/watch?v=test'
+
+  await prisma.$executeRaw`
+    INSERT INTO lessons (course_id, title, description, youtube_url, position, created_at, updated_at)
+    VALUES (${overrides.courseId}, ${title}, ${description}, ${youtubeUrl}, ${overrides.position}, NOW(), NOW())
+  `
+
+  const rows = await prisma.$queryRaw`SELECT LAST_INSERT_ID() as id` as Array<{ id: bigint }>
+  return Number(rows[0]!.id)
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describeOrSkip('Admin CRUD Courses', () => {
+  beforeAll(async () => {
+    await setupDb()
+  })
+
+  beforeEach(async () => {
+    await truncateAll()
+  })
+
+  afterAll(async () => {
+    await teardownDb()
+  })
+
+  // ────────────────────────────────────────
+  // POST /api/v1/courses
+  // ────────────────────────────────────────
+  describe('POST /api/v1/courses', () => {
+    it('AC-01: should create a course with status draft and return 201', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await post<CourseResponse>(
+        '/api/v1/courses',
+        { title: 'New Course', description: 'A brand new course' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(201)
+      expect(res.body.data).toMatchObject({
+        title: 'New Course',
+        description: 'A brand new course',
+        status: 'draft',
+        thumbnailUrl: null,
+      })
+      expect(res.body.data.id).toBeTypeOf('number')
+      expect(res.body.requestId).toBeTypeOf('string')
+    })
+
+    it('AC-02: should return 400 for missing title', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await post<ErrorResponse>(
+        '/api/v1/courses',
+        { description: 'No title provided' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('AC-02: should return 400 for empty title', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await post<ErrorResponse>(
+        '/api/v1/courses',
+        { title: '', description: 'Empty title' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('AC-03: should return 401 without auth token', async () => {
+      const res = await post<ErrorResponse>('/api/v1/courses', {
+        title: 'Unauthorized',
+        description: 'No token',
+      })
+
+      expect(res.status).toBe(401)
+      expect(res.body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('AC-04: should return 403 for learner user', async () => {
+      const { token } = await registerAndLogin()
+
+      const res = await post<ErrorResponse>(
+        '/api/v1/courses',
+        { title: 'Forbidden', description: 'Learner cannot create' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(403)
+      expect(res.body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ────────────────────────────────────────
+  // PUT /api/v1/courses/:id
+  // ────────────────────────────────────────
+  describe('PUT /api/v1/courses/:id', () => {
+    it('AC-05: should update course metadata and return 200', async () => {
+      const { token } = await seedAdminAndLogin()
+      const courseId = await seedCourse({ title: 'Old Title', description: 'Old Desc' })
+
+      const res = await put<CourseResponse>(
+        `/api/v1/courses/${courseId}`,
+        { title: 'New Title', description: 'New Desc' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.title).toBe('New Title')
+      expect(res.body.data.description).toBe('New Desc')
+      expect(res.body.requestId).toBeTypeOf('string')
+    })
+
+    it('should return 404 when course does not exist', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await put<ErrorResponse>(
+        '/api/v1/courses/99999',
+        { title: 'Does Not Exist' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('should return 401 without auth token', async () => {
+      const courseId = await seedCourse()
+
+      const res = await put<ErrorResponse>(
+        `/api/v1/courses/${courseId}`,
+        { title: 'No Auth' },
+      )
+
+      expect(res.status).toBe(401)
+      expect(res.body.error.code).toBe('UNAUTHORIZED')
+    })
+
+    it('should return 403 for learner user', async () => {
+      const { token } = await registerAndLogin()
+      const courseId = await seedCourse()
+
+      const res = await put<ErrorResponse>(
+        `/api/v1/courses/${courseId}`,
+        { title: 'Forbidden' },
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(403)
+      expect(res.body.error.code).toBe('FORBIDDEN')
+    })
+  })
+
+  // ────────────────────────────────────────
+  // PATCH /api/v1/courses/:id/publish
+  // ────────────────────────────────────────
+  describe('PATCH /api/v1/courses/:id/publish', () => {
+    it('AC-05: should publish course when prerequisites are met', async () => {
+      const { token } = await seedAdminAndLogin()
+      const courseId = await seedCourse({ title: 'Publishable', description: 'Has desc', status: 'draft' })
+      await seedLesson({ courseId, position: 1 })
+
+      const res = await patch<CourseResponse>(
+        `/api/v1/courses/${courseId}/publish`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('published')
+      expect(res.body.requestId).toBeTypeOf('string')
+    })
+
+    it('AC-06: should return 400 when course has no lessons', async () => {
+      const { token } = await seedAdminAndLogin()
+      const courseId = await seedCourse({ title: 'No Lessons', description: 'Has desc', status: 'draft' })
+
+      const res = await patch<ErrorResponse>(
+        `/api/v1/courses/${courseId}/publish`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+      expect(res.body.error.message).toContain('Cannot publish course')
+    })
+
+    it('should return 404 when course does not exist', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await patch<ErrorResponse>(
+        '/api/v1/courses/99999/publish',
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('should return 401 without auth token', async () => {
+      const courseId = await seedCourse()
+
+      const res = await patch<ErrorResponse>(`/api/v1/courses/${courseId}/publish`)
+
+      expect(res.status).toBe(401)
+    })
+
+    it('should return 403 for learner user', async () => {
+      const { token } = await registerAndLogin()
+      const courseId = await seedCourse()
+
+      const res = await patch<ErrorResponse>(
+        `/api/v1/courses/${courseId}/publish`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  // ────────────────────────────────────────
+  // PATCH /api/v1/courses/:id/unpublish
+  // ────────────────────────────────────────
+  describe('PATCH /api/v1/courses/:id/unpublish', () => {
+    it('AC-07: should unpublish course and return 200', async () => {
+      const { token } = await seedAdminAndLogin()
+      const courseId = await seedCourse({ title: 'Published', description: 'Desc', status: 'published' })
+
+      const res = await patch<CourseResponse>(
+        `/api/v1/courses/${courseId}/unpublish`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('unpublished')
+      expect(res.body.requestId).toBeTypeOf('string')
+    })
+
+    it('should return 404 when course does not exist', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await patch<ErrorResponse>(
+        '/api/v1/courses/99999/unpublish',
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('should return 401 without auth token', async () => {
+      const courseId = await seedCourse()
+
+      const res = await patch<ErrorResponse>(`/api/v1/courses/${courseId}/unpublish`)
+
+      expect(res.status).toBe(401)
+    })
+
+    it('should return 403 for learner user', async () => {
+      const { token } = await registerAndLogin()
+      const courseId = await seedCourse()
+
+      const res = await patch<ErrorResponse>(
+        `/api/v1/courses/${courseId}/unpublish`,
+        {},
+        { Authorization: `Bearer ${token}` },
+      )
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  // ────────────────────────────────────────
+  // DELETE /api/v1/courses/:id
+  // ────────────────────────────────────────
+  describe('DELETE /api/v1/courses/:id', () => {
+    it('AC-08: should delete course and return 204', async () => {
+      const { token } = await seedAdminAndLogin()
+      const courseId = await seedCourse({ title: 'To Delete' })
+
+      const res = await del(`/api/v1/courses/${courseId}`, {
+        Authorization: `Bearer ${token}`,
+      })
+
+      expect(res.status).toBe(204)
+
+      // Verify course no longer exists in DB
+      const prisma = getTestPrisma()
+      const rows = await prisma.$queryRaw`SELECT id FROM courses WHERE id = ${courseId}` as Array<{ id: number }>
+      expect(rows).toHaveLength(0)
+    })
+
+    it('should return 404 when course does not exist', async () => {
+      const { token } = await seedAdminAndLogin()
+
+      const res = await del<ErrorResponse>('/api/v1/courses/99999', {
+        Authorization: `Bearer ${token}`,
+      })
+
+      expect(res.status).toBe(404)
+      expect(res.body.error.code).toBe('NOT_FOUND')
+    })
+
+    it('should return 401 without auth token', async () => {
+      const courseId = await seedCourse()
+
+      const res = await del<ErrorResponse>(`/api/v1/courses/${courseId}`)
+
+      expect(res.status).toBe(401)
+    })
+
+    it('should return 403 for learner user', async () => {
+      const { token } = await registerAndLogin()
+      const courseId = await seedCourse()
+
+      const res = await del<ErrorResponse>(`/api/v1/courses/${courseId}`, {
+        Authorization: `Bearer ${token}`,
+      })
+
+      expect(res.status).toBe(403)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #30 — **Admin CRUD Courses + Admin Guard Middleware**.

Adds 5 admin endpoints for course management and a reusable admin guard middleware.

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/v1/courses` | Create course (draft) |
| `PUT` | `/api/v1/courses/:id` | Update course metadata |
| `PATCH` | `/api/v1/courses/:id/publish` | Publish (validates prerequisites) |
| `PATCH` | `/api/v1/courses/:id/unpublish` | Unpublish course |
| `DELETE` | `/api/v1/courses/:id` | Delete course |

## Changes

| File | Action | Purpose |
|------|--------|---------|
| `backend/src/middlewares/admin-guard.ts` | create | Role check middleware (403 if not admin) |
| `backend/src/dto/admin-course-dto.ts` | create | Zod schemas for create/update body + path params |
| `backend/src/services/admin-course-service.ts` | create | Admin business logic with publish validation |
| `backend/src/controllers/admin-course-controller.ts` | create | 5 endpoint handlers with auth guard |
| `backend/src/routes/admin-course-routes.ts` | create | Route registration with auth + admin middleware |
| `backend/src/routes/index.ts` | modify | DI wiring |
| `backend/test/unit/middlewares/admin-guard.spec.ts` | create | 4 unit tests |
| `backend/test/unit/services/admin-course-service.spec.ts` | create | 11 unit tests |
| `integration-tests/test/api/admin-courses.spec.ts` | create | Integration tests (AC-01 to AC-08) |

## Acceptance Criteria

- ✅ AC-01: Admin guard (403 for learners, allow admin)
- ✅ AC-02: Create course (draft status)
- ✅ AC-03: Update course metadata
- ✅ AC-04: Publish course (title + description + ≥1 lesson)
- ✅ AC-05: Publish fails if prerequisites not met (400)
- ✅ AC-06: Unpublish course
- ✅ AC-07: Delete course
- ✅ AC-08: Course not found → 404

## Tests
- **71 unit tests pass** (15 new + 56 existing)
- Integration tests ready (`RUN_INTEGRATION_TESTS=true`)

Closes #30