### PR TITLE
feat(frontend): Etapa 2 — Homepage + Course Catalog with SSG/ISR

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {}
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
+}
 
 export default nextConfig

--- a/frontend/public/images/course-placeholder.svg
+++ b/frontend/public/images/course-placeholder.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 225" fill="none">
+  <rect width="400" height="225" fill="#F3F4F6"/>
+  <path d="M180 90h40v45h-40z" fill="#D1D5DB"/>
+  <path d="M190 100h20v5h-20zM190 110h20v5h-20zM190 120h15v5h-15z" fill="#9CA3AF"/>
+  <circle cx="200" cy="75" r="15" fill="#D1D5DB"/>
+  <text x="200" y="160" text-anchor="middle" fill="#9CA3AF" font-size="14" font-family="system-ui">Sem thumbnail</text>
+</svg>

--- a/frontend/src/app/__tests__/page.spec.tsx
+++ b/frontend/src/app/__tests__/page.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text */
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -7,25 +8,65 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props
+    return <img {...rest} data-fill={fill ? 'true' : undefined} />
+  },
+}))
+
+vi.mock('@/services/course-service', () => ({
+  listCourses: vi.fn().mockResolvedValue({
+    courses: [
+      {
+        id: 1,
+        title: 'Curso de Teste',
+        description: 'Descrição do curso',
+        thumbnailUrl: null,
+        status: 'published',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    meta: { page: 1, pageSize: 6, totalItems: 1, totalPages: 1 },
+  }),
+}))
+
 import HomePage from '../page'
 
 describe('HomePage', () => {
-  it('deve renderizar sem crash', () => {
-    render(<HomePage />)
+  it('deve renderizar sem crash', async () => {
+    const Page = await HomePage()
+    render(Page)
   })
 
-  it('deve exibir o título "Dude Course"', () => {
-    render(<HomePage />)
+  it('deve exibir o título "Dude Course"', async () => {
+    const Page = await HomePage()
+    render(Page)
     expect(screen.getByRole('heading', { name: /dude course/i })).toBeInTheDocument()
   })
 
-  it('deve exibir link para /login', () => {
-    render(<HomePage />)
-    expect(screen.getByRole('link', { name: /entrar/i })).toHaveAttribute('href', '/login')
+  it('deve exibir link para explorar cursos', async () => {
+    const Page = await HomePage()
+    render(Page)
+    expect(screen.getByRole('link', { name: /explorar cursos/i })).toHaveAttribute('href', '/courses')
   })
 
-  it('deve exibir link para /register', () => {
-    render(<HomePage />)
+  it('deve exibir link para criar conta', async () => {
+    const Page = await HomePage()
+    render(Page)
     expect(screen.getByRole('link', { name: /criar conta/i })).toHaveAttribute('href', '/register')
+  })
+
+  it('deve exibir seção de cursos em destaque', async () => {
+    const Page = await HomePage()
+    render(Page)
+    expect(screen.getByText('Cursos em Destaque')).toBeInTheDocument()
+  })
+
+  it('deve renderizar cursos quando disponíveis', async () => {
+    const Page = await HomePage()
+    render(Page)
+    expect(screen.getByText('Curso de Teste')).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/courses/loading.tsx
+++ b/frontend/src/app/courses/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+
+export default function CoursesLoading() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <LoadingSpinner size="lg" />
+    </div>
+  )
+}

--- a/frontend/src/app/courses/page.tsx
+++ b/frontend/src/app/courses/page.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link'
+import { CourseList } from '@/components/course/CourseList'
+import { ErrorMessage } from '@/components/ui/ErrorMessage'
+import { listCourses } from '@/services/course-service'
+
+export const revalidate = 60
+
+interface CoursesPageProps {
+  searchParams: Promise<{ page?: string }>
+}
+
+export default async function CoursesPage({ searchParams }: CoursesPageProps) {
+  const params = await searchParams
+  const currentPage = Math.max(1, Number(params.page) || 1)
+
+  let courses: Awaited<ReturnType<typeof listCourses>>['courses'] = []
+  let totalPages = 1
+  let error: string | null = null
+
+  try {
+    const result = await listCourses(currentPage, 20)
+    courses = result.courses
+    totalPages = result.meta.totalPages
+  } catch {
+    error = 'Não foi possível carregar os cursos. Tente novamente mais tarde.'
+  }
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Catálogo de Cursos</h1>
+        <p className="mt-2 text-gray-600">
+          Explore nossos cursos e comece a aprender agora.
+        </p>
+      </div>
+
+      {error ? (
+        <ErrorMessage message={error} />
+      ) : (
+        <>
+          <CourseList courses={courses} />
+
+          {totalPages > 1 && (
+            <nav className="mt-8 flex justify-center" aria-label="Paginação do catálogo">
+              <div className="flex items-center gap-2">
+                {currentPage > 1 && (
+                  <Link
+                    href={`/courses?page=${currentPage - 1}`}
+                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    aria-label="Página anterior"
+                  >
+                    ← Anterior
+                  </Link>
+                )}
+                <span className="px-4 py-2 text-sm text-gray-600">
+                  Página {currentPage} de {totalPages}
+                </span>
+                {currentPage < totalPages && (
+                  <Link
+                    href={`/courses?page=${currentPage + 1}`}
+                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    aria-label="Próxima página"
+                  >
+                    Próxima →
+                  </Link>
+                )}
+              </div>
+            </nav>
+          )}
+        </>
+      )}
+    </main>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,27 +1,62 @@
 import Link from 'next/link'
+import { CourseList } from '@/components/course/CourseList'
+import { listCourses } from '@/services/course-service'
 
-// TODO: Expandir para landing page completa (catálogo de cursos, destaques, etc.)
-export default function HomePage() {
+export const revalidate = 60
+
+export default async function HomePage() {
+  let featuredCourses: Awaited<ReturnType<typeof listCourses>>['courses'] = []
+
+  try {
+    const result = await listCourses(1, 6)
+    featuredCourses = result.courses
+  } catch {
+    // Fail silently — show hero without courses
+  }
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <h1 className="mb-4 text-4xl font-bold">Dude Course</h1>
-      <p className="mb-10 text-xl text-gray-600">
-        Plataforma educacional com cursos estruturados e certificados
-      </p>
-      <div className="flex gap-4">
-        <Link
-          href="/login"
-          className="rounded-lg bg-blue-600 px-6 py-3 text-white transition-colors hover:bg-blue-700"
-        >
-          Entrar
-        </Link>
-        <Link
-          href="/register"
-          className="rounded-lg border border-blue-600 px-6 py-3 text-blue-600 transition-colors hover:bg-blue-50"
-        >
-          Criar conta
-        </Link>
-      </div>
+    <main>
+      {/* Hero Section */}
+      <section className="bg-gradient-to-br from-blue-600 to-blue-800 px-4 py-20 text-white sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl text-center">
+          <h1 className="mb-4 text-4xl font-bold sm:text-5xl">Dude Course</h1>
+          <p className="mb-8 text-lg text-blue-100 sm:text-xl">
+            Plataforma educacional com cursos estruturados e certificados.
+            Aprenda no seu ritmo com conteúdo de qualidade.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/courses"
+              className="rounded-lg bg-white px-8 py-3 font-semibold text-blue-700 transition-colors hover:bg-blue-50"
+            >
+              Explorar Cursos
+            </Link>
+            <Link
+              href="/register"
+              className="rounded-lg border-2 border-white px-8 py-3 font-semibold text-white transition-colors hover:bg-white/10"
+            >
+              Criar Conta
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Courses */}
+      <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mb-8 flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-gray-900">Cursos em Destaque</h2>
+          <Link
+            href="/courses"
+            className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            Ver todos →
+          </Link>
+        </div>
+        <CourseList
+          courses={featuredCourses}
+          emptyMessage="Novos cursos estão chegando em breve!"
+        />
+      </section>
     </main>
   )
 }

--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import type { Course } from '@/services/types/course'
+
+interface CourseCardProps {
+  course: Course
+}
+
+const FALLBACK_THUMBNAIL = '/images/course-placeholder.svg'
+
+export function CourseCard({ course }: CourseCardProps) {
+  return (
+    <Link
+      href={`/courses/${course.id}`}
+      className="group overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div className="relative aspect-video w-full overflow-hidden bg-gray-100">
+        <Image
+          src={course.thumbnailUrl || FALLBACK_THUMBNAIL}
+          alt={`Thumbnail de ${course.title}`}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover transition-transform group-hover:scale-105"
+          onError={(e) => {
+            const target = e.target as HTMLImageElement
+            target.src = FALLBACK_THUMBNAIL
+          }}
+        />
+      </div>
+      <div className="p-4">
+        <h3 className="mb-1 line-clamp-2 text-lg font-semibold text-gray-900 group-hover:text-blue-600">
+          {course.title}
+        </h3>
+        <p className="line-clamp-2 text-sm text-gray-600">{course.description}</p>
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/components/course/CourseList.tsx
+++ b/frontend/src/components/course/CourseList.tsx
@@ -1,0 +1,22 @@
+import type { Course } from '@/services/types/course'
+import { CourseCard } from './CourseCard'
+import { EmptyState } from '@/components/ui/EmptyState'
+
+interface CourseListProps {
+  courses: Course[]
+  emptyMessage?: string
+}
+
+export function CourseList({ courses, emptyMessage = 'Nenhum curso disponível no momento.' }: CourseListProps) {
+  if (courses.length === 0) {
+    return <EmptyState message={emptyMessage} icon="📚" />
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {courses.map((course) => (
+        <CourseCard key={course.id} course={course} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/course/ProgressBar.tsx
+++ b/frontend/src/components/course/ProgressBar.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/lib/utils'
+
+interface ProgressBarProps {
+  completed: number
+  total: number
+  className?: string
+}
+
+export function ProgressBar({ completed, total, className }: ProgressBarProps) {
+  const percentage = total > 0 ? Math.round((completed / total) * 100) : 0
+
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <div
+        className="h-2 flex-1 overflow-hidden rounded-full bg-gray-200"
+        role="progressbar"
+        aria-valuenow={percentage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${percentage}% concluído`}
+      >
+        <div
+          className={cn(
+            'h-full rounded-full transition-all',
+            percentage === 100 ? 'bg-green-500' : 'bg-blue-500',
+          )}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <span className="text-xs font-medium text-gray-600">{percentage}%</span>
+    </div>
+  )
+}

--- a/frontend/src/components/course/__tests__/CourseCard.spec.tsx
+++ b/frontend/src/components/course/__tests__/CourseCard.spec.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { CourseCard } from '../CourseCard'
+import type { Course } from '@/services/types/course'
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props
+    return <img {...rest} data-fill={fill ? 'true' : undefined} />
+  },
+}))
+
+const mockCourse: Course = {
+  id: 1,
+  title: 'Node.js Fundamentals',
+  description: 'Learn Node.js from scratch with hands-on projects',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  status: 'published',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+describe('CourseCard', () => {
+  it('deve renderizar título do curso', () => {
+    render(<CourseCard course={mockCourse} />)
+    expect(screen.getByText('Node.js Fundamentals')).toBeInTheDocument()
+  })
+
+  it('deve renderizar descrição do curso', () => {
+    render(<CourseCard course={mockCourse} />)
+    expect(screen.getByText(/Learn Node.js from scratch/)).toBeInTheDocument()
+  })
+
+  it('deve ter link para /courses/:id', () => {
+    render(<CourseCard course={mockCourse} />)
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/courses/1')
+  })
+
+  it('deve renderizar imagem com alt correto', () => {
+    render(<CourseCard course={mockCourse} />)
+    expect(screen.getByAltText('Thumbnail de Node.js Fundamentals')).toBeInTheDocument()
+  })
+
+  it('deve usar thumbnail fornecida', () => {
+    render(<CourseCard course={mockCourse} />)
+    const img = screen.getByAltText('Thumbnail de Node.js Fundamentals')
+    expect(img).toHaveAttribute('src', 'https://example.com/thumb.jpg')
+  })
+
+  it('deve usar fallback quando thumbnailUrl é null', () => {
+    const courseNoThumb = { ...mockCourse, thumbnailUrl: null }
+    render(<CourseCard course={courseNoThumb} />)
+    const img = screen.getByAltText('Thumbnail de Node.js Fundamentals')
+    expect(img).toHaveAttribute('src', '/images/course-placeholder.svg')
+  })
+})

--- a/frontend/src/components/course/__tests__/CourseList.spec.tsx
+++ b/frontend/src/components/course/__tests__/CourseList.spec.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable @next/next/no-img-element, jsx-a11y/alt-text */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { CourseList } from '../CourseList'
+import type { Course } from '@/services/types/course'
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { fill, ...rest } = props
+    return <img {...rest} data-fill={fill ? 'true' : undefined} />
+  },
+}))
+
+const mockCourses: Course[] = [
+  {
+    id: 1,
+    title: 'Course A',
+    description: 'Description A',
+    thumbnailUrl: null,
+    status: 'published',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 2,
+    title: 'Course B',
+    description: 'Description B',
+    thumbnailUrl: null,
+    status: 'published',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 3,
+    title: 'Course C',
+    description: 'Description C',
+    thumbnailUrl: null,
+    status: 'published',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+]
+
+describe('CourseList', () => {
+  it('deve renderizar N cards de curso', () => {
+    render(<CourseList courses={mockCourses} />)
+    expect(screen.getAllByRole('link')).toHaveLength(3)
+  })
+
+  it('deve renderizar os títulos dos cursos', () => {
+    render(<CourseList courses={mockCourses} />)
+    expect(screen.getByText('Course A')).toBeInTheDocument()
+    expect(screen.getByText('Course B')).toBeInTheDocument()
+    expect(screen.getByText('Course C')).toBeInTheDocument()
+  })
+
+  it('deve exibir empty state quando array vazio', () => {
+    render(<CourseList courses={[]} />)
+    expect(screen.getByText('Nenhum curso disponível no momento.')).toBeInTheDocument()
+  })
+
+  it('deve aceitar mensagem de empty state customizada', () => {
+    render(<CourseList courses={[]} emptyMessage="Nada aqui" />)
+    expect(screen.getByText('Nada aqui')).toBeInTheDocument()
+  })
+
+  it('deve ter grid layout', () => {
+    const { container } = render(<CourseList courses={mockCourses} />)
+    const grid = container.firstChild as HTMLElement
+    expect(grid.className).toContain('grid')
+    expect(grid.className).toContain('grid-cols-1')
+    expect(grid.className).toContain('sm:grid-cols-2')
+    expect(grid.className).toContain('lg:grid-cols-3')
+  })
+})

--- a/frontend/src/components/course/__tests__/ProgressBar.spec.tsx
+++ b/frontend/src/components/course/__tests__/ProgressBar.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ProgressBar } from '../ProgressBar'
+
+describe('ProgressBar', () => {
+  it('deve renderizar porcentagem correta', () => {
+    render(<ProgressBar completed={5} total={10} />)
+    expect(screen.getByText('50%')).toBeInTheDocument()
+  })
+
+  it('deve exibir 0% quando total é 0', () => {
+    render(<ProgressBar completed={0} total={0} />)
+    expect(screen.getByText('0%')).toBeInTheDocument()
+  })
+
+  it('deve exibir 100% quando tudo completado', () => {
+    render(<ProgressBar completed={10} total={10} />)
+    expect(screen.getByText('100%')).toBeInTheDocument()
+  })
+
+  it('deve ter role=progressbar', () => {
+    render(<ProgressBar completed={3} total={10} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('deve ter aria-valuenow correto', () => {
+    render(<ProgressBar completed={7} total={10} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '70')
+  })
+
+  it('deve ter aria-label acessível', () => {
+    render(<ProgressBar completed={3} total={10} />)
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', '30% concluído')
+  })
+
+  it('deve arredondar porcentagem', () => {
+    render(<ProgressBar completed={1} total={3} />)
+    expect(screen.getByText('33%')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/course/index.ts
+++ b/frontend/src/components/course/index.ts
@@ -1,3 +1,3 @@
-// TODO: Implementar componentes específicos de curso
-// Exemplos: CourseCard, CourseList, LessonItem, ProgressBar
-// Exportar os componentes aqui conforme forem criados
+export { CourseCard } from './CourseCard'
+export { CourseList } from './CourseList'
+export { ProgressBar } from './ProgressBar'

--- a/frontend/src/services/__tests__/course-service.spec.ts
+++ b/frontend/src/services/__tests__/course-service.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { listCourses, getCourse } from '../course-service'
+
+const mockApiRequest = vi.fn()
+vi.mock('../api', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}))
+
+describe('courseService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  describe('listCourses', () => {
+    it('deve chamar fetch com parâmetros corretos', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [{ id: 1, title: 'Test' }],
+          meta: { page: 1, pageSize: 20, totalItems: 1, totalPages: 1 },
+          requestId: 'req-1',
+        }),
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse as unknown as Response)
+
+      const result = await listCourses(1, 20)
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/courses?page=1&pageSize=20'),
+        expect.objectContaining({ next: { revalidate: 60 } }),
+      )
+      expect(result.courses).toHaveLength(1)
+      expect(result.meta.totalPages).toBe(1)
+    })
+
+    it('deve lançar erro quando response não é ok', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as Response)
+
+      await expect(listCourses()).rejects.toThrow('Failed to fetch courses: 500')
+    })
+
+    it('deve usar valores padrão page=1 pageSize=20', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [],
+          meta: { page: 1, pageSize: 20, totalItems: 0, totalPages: 0 },
+          requestId: 'req-1',
+        }),
+      }
+      vi.mocked(fetch).mockResolvedValueOnce(mockResponse as unknown as Response)
+
+      await listCourses()
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('page=1&pageSize=20'),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('getCourse', () => {
+    it('deve chamar apiRequest com path correto', async () => {
+      const mockCourse = { id: 1, title: 'Test', lessons: [] }
+      mockApiRequest.mockResolvedValueOnce({ data: mockCourse, requestId: 'req-1' })
+
+      const result = await getCourse(1)
+
+      expect(mockApiRequest).toHaveBeenCalledWith('/courses/1')
+      expect(result).toEqual(mockCourse)
+    })
+  })
+})

--- a/frontend/src/services/course-service.ts
+++ b/frontend/src/services/course-service.ts
@@ -1,0 +1,41 @@
+import { apiRequest } from './api'
+import type { Course, CourseWithLessons, PaginationMeta } from './types/course'
+
+interface ListCoursesResponse {
+  data: Course[]
+  meta: PaginationMeta
+  requestId: string
+}
+
+/**
+ * Lista cursos publicados do catálogo público.
+ */
+export async function listCourses(
+  page = 1,
+  pageSize = 20,
+): Promise<{ courses: Course[]; meta: PaginationMeta }> {
+  const params = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+  })
+
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api/v1'}/courses?${params}`,
+    { next: { revalidate: 60 } },
+  )
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch courses: ${response.status}`)
+  }
+
+  const json: ListCoursesResponse = await response.json()
+  return { courses: json.data, meta: json.meta }
+}
+
+/**
+ * Retorna o detalhe de um curso com suas lessons.
+ */
+export async function getCourse(id: number): Promise<CourseWithLessons> {
+  const { data } = await apiRequest<CourseWithLessons>(`/courses/${id}`)
+  return data
+}

--- a/frontend/src/services/types/course.ts
+++ b/frontend/src/services/types/course.ts
@@ -1,0 +1,34 @@
+export interface Course {
+  id: number
+  title: string
+  description: string
+  thumbnailUrl: string | null
+  status: 'draft' | 'published' | 'unpublished'
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Lesson {
+  id: number
+  title: string
+  description: string
+  youtubeUrl: string
+  position: number
+}
+
+export interface CourseWithLessons extends Course {
+  lessons: Lesson[]
+}
+
+export interface PaginationMeta {
+  page: number
+  pageSize: number
+  totalItems: number
+  totalPages: number
+}
+
+export interface PaginatedResponse<T> {
+  data: T[]
+  meta: PaginationMeta
+  requestId: string
+}


### PR DESCRIPTION
## Summary

Implements **Etapa 2 (#56)** — Homepage expansion and public course catalog with SSG/ISR rendering.

### What's included

#### Course Types (`services/types/course.ts`)
- `Course`, `Lesson`, `CourseWithLessons`, `PaginationMeta`, `PaginatedResponse`
- Typed to match `docs/api-spec.md` response shapes

#### Course Service (`services/course-service.ts`)
- `listCourses(page, pageSize)` — uses `fetch()` directly with `{ next: { revalidate: 60 } }` for ISR
- `getCourse(id)` — uses `apiRequest` for client-side usage

#### Course Components
- **CourseCard** — `next/image` with fallback placeholder, link to `/courses/:id`, hover effects, truncated text
- **CourseList** — responsive grid (1 col mobile, 2 tablet, 3 desktop), `EmptyState` when empty
- **ProgressBar** — accessible progress bar with `role=progressbar`, `aria-valuenow`, green at 100%

#### Pages
- **Homepage** (`app/page.tsx`) — async Server Component with hero section + "Cursos em Destaque" (up to 6 courses, ISR 60s). Graceful empty state.
- **Catalog** (`app/courses/page.tsx`) — server-rendered paginated listing with `searchParams`, link-based pagination, error/empty states
- **Loading** (`app/courses/loading.tsx`) — Next.js Suspense loading UI

#### Infrastructure
- `next.config.ts` — remote image patterns for course thumbnails
- Placeholder SVG for courses without thumbnails
- Updated barrel export for course components

### Rendering Strategy
| Page | Strategy | Revalidation |
|------|----------|-------------|
| `/` (Homepage) | ISR | 60s |
| `/courses` | Dynamic SSR | Per-request (searchParams) |

### Tests — 22 new tests, all passing ✅

| Area | Tests |
|------|-------|
| CourseCard | 6 (title, description, link, alt, thumbnail, fallback) |
| CourseList | 5 (N cards, titles, empty state, custom message, grid) |
| ProgressBar | 7 (percentage, 0%, 100%, progressbar role, aria, label, rounding) |
| courseService | 4 (listCourses params, error, defaults, getCourse) |
| Homepage (updated) | 6 (render, title, explore link, register link, featured section, course data) |

### Verification
- ✅ `pnpm --filter frontend test` — 115/115 passing (91 existing + 2 updated + 22 new)
- ✅ `pnpm --filter frontend lint` — clean
- ✅ `pnpm --filter frontend build` — production build successful
- ✅ Pre-push hook — 160 backend tests passing

Closes #56
Part of #53