### PR TITLE
feat(frontend): Etapa 6 — Polish: Error Handling, 404, 401 Auto-Redirect (#60)

### DIFF
--- a/frontend/src/app/__tests__/error.spec.tsx
+++ b/frontend/src/app/__tests__/error.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}))
+
+const { default: GlobalError } = await import('../../app/error')
+
+describe('GlobalError (Error Boundary)', () => {
+  it('deve exibir mensagem de erro amigável', () => {
+    const error = new Error('Test error')
+    render(<GlobalError error={error} reset={vi.fn()} />)
+    expect(screen.getByText('Algo deu errado')).toBeInTheDocument()
+  })
+
+  it('deve ter botão de retry', () => {
+    const error = new Error('Test')
+    render(<GlobalError error={error} reset={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /tentar novamente/i })).toBeInTheDocument()
+  })
+
+  it('deve chamar reset ao clicar retry', async () => {
+    const reset = vi.fn()
+    const error = new Error('Test')
+    render(<GlobalError error={error} reset={reset} />)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /tentar novamente/i }))
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it('deve ter link para homepage', () => {
+    const error = new Error('Test')
+    render(<GlobalError error={error} reset={vi.fn()} />)
+    const link = screen.getByRole('link', { name: /ir para o início/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/frontend/src/app/__tests__/not-found.spec.tsx
+++ b/frontend/src/app/__tests__/not-found.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}))
+
+// Must import after mock
+const { default: NotFound } = await import('../../app/not-found')
+
+describe('NotFound (404)', () => {
+  it('deve exibir título 404', () => {
+    render(<NotFound />)
+    expect(screen.getByText('404')).toBeInTheDocument()
+  })
+
+  it('deve exibir mensagem amigável', () => {
+    render(<NotFound />)
+    expect(screen.getByText('Página não encontrada')).toBeInTheDocument()
+  })
+
+  it('deve ter link para homepage', () => {
+    render(<NotFound />)
+    const link = screen.getByRole('link', { name: /voltar para o início/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/frontend/src/app/dashboard/loading.tsx
+++ b/frontend/src/app/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+
+export default function DashboardLoading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <LoadingSpinner size="lg" />
+    </div>
+  )
+}

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/Button'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Log error for observability
+    console.error('[ErrorBoundary]', error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
+      <div className="mb-4 text-6xl">⚠️</div>
+      <h1 className="mb-2 text-2xl font-bold text-gray-900">
+        Algo deu errado
+      </h1>
+      <p className="mb-6 max-w-md text-gray-600">
+        Ocorreu um erro inesperado. Tente novamente ou volte para a página
+        inicial.
+      </p>
+      <div className="flex gap-3">
+        <Button onClick={reset}>Tentar novamente</Button>
+        <Link href="/">
+          <Button variant="secondary">Ir para o início</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
+      <div className="mb-4 text-7xl font-bold text-gray-200">404</div>
+      <h1 className="mb-2 text-2xl font-bold text-gray-900">
+        Página não encontrada
+      </h1>
+      <p className="mb-6 max-w-md text-gray-600">
+        A página que você procura não existe ou foi removida.
+      </p>
+      <Link
+        href="/"
+        className="rounded-lg bg-blue-600 px-6 py-2 font-medium text-white transition-colors hover:bg-blue-700"
+      >
+        Voltar para o início
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/hooks/use-auth.tsx
+++ b/frontend/src/hooks/use-auth.tsx
@@ -15,6 +15,7 @@ import {
   logout as authLogout,
   getStoredToken,
 } from '@/services/auth-service'
+import { setOnUnauthorized } from '@/services/api'
 import type { LoginResponse, UserInfo } from '@/services/auth-service'
 
 interface AuthContextValue {
@@ -80,6 +81,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     authLogout()
     localStorage.removeItem(USER_KEY)
   }, [])
+
+  // Register global 401 handler so API calls auto-redirect on token expiry
+  useEffect(() => {
+    setOnUnauthorized(handleUnauthorized)
+    return () => setOnUnauthorized(null)
+  }, [handleUnauthorized])
 
   // Auto-logout when token expires
   useEffect(() => {

--- a/frontend/src/services/__tests__/api-401.spec.ts
+++ b/frontend/src/services/__tests__/api-401.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { apiRequest, AppError, setOnUnauthorized } from '../api'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('api 401 auto-redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setOnUnauthorized(null)
+  })
+
+  it('deve chamar handler global ao receber 401', async () => {
+    const handler = vi.fn()
+    setOnUnauthorized(handler)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: new Headers({ 'x-request-id': 'r1' }),
+      json: async () => ({ error: { code: 'UNAUTHORIZED', message: 'Token expired' } }),
+    })
+
+    await expect(apiRequest('/test')).rejects.toThrow(AppError)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('não deve chamar handler para outros erros', async () => {
+    const handler = vi.fn()
+    setOnUnauthorized(handler)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      headers: new Headers({ 'x-request-id': 'r2' }),
+      json: async () => ({ error: { code: 'NOT_FOUND', message: 'Not found' } }),
+    })
+
+    await expect(apiRequest('/test')).rejects.toThrow(AppError)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('não deve falhar sem handler registrado', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: new Headers({ 'x-request-id': 'r3' }),
+      json: async () => ({ error: { code: 'UNAUTHORIZED', message: 'Expired' } }),
+    })
+
+    await expect(apiRequest('/test')).rejects.toThrow(AppError)
+  })
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,6 +35,17 @@ function getToken(): string | null {
   return localStorage.getItem('auth_token')
 }
 
+/** Global handler for 401 responses (token expired / invalid). */
+let onUnauthorizedHandler: (() => void) | null = null
+
+/**
+ * Register a global handler to be called when API returns 401.
+ * Used by AuthProvider to auto-logout + redirect.
+ */
+export function setOnUnauthorized(handler: (() => void) | null): void {
+  onUnauthorizedHandler = handler
+}
+
 interface RequestOptions extends Omit<RequestInit, 'body'> {
   body?: unknown
 }
@@ -74,6 +85,11 @@ export async function apiRequest<T = unknown>(
     const err = errorBody.error
     const code = err?.code ?? httpStatusToCode(response.status)
     const message = err?.message ?? httpStatusToMessage(response.status)
+
+    // Auto-handle 401: notify global handler for token expiry
+    if (response.status === 401 && onUnauthorizedHandler) {
+      onUnauthorizedHandler()
+    }
 
     throw new AppError(code, message, requestId, err?.details)
   }


### PR DESCRIPTION
# Etapa 6 — Polimento: Error Handling, Loading States, 401 Auto-Redirect

Closes #60

## Summary
Polishes the frontend application with global error handling, custom 404 page, loading states, and automatic token expiry handling.

## Changes

### Error Handling
| File | Purpose |
|------|---------|
| `app/error.tsx` | Global error boundary — friendly message + retry button + homepage link |
| `app/not-found.tsx` | Custom 404 page with "Voltar para o início" CTA |

### Loading States
| File | Purpose |
|------|---------|
| `app/dashboard/loading.tsx` | Loading spinner for dashboard route |
| `app/courses/loading.tsx` | Already existed from Etapa 2 |

### 401 Auto-Redirect (Token Expiry)
| File | Change |
|------|--------|
| `services/api.ts` | Added `setOnUnauthorized()` global handler + 401 detection in `apiRequest` |
| `hooks/use-auth.tsx` | Registers `handleUnauthorized` as global 401 handler via `setOnUnauthorized` |

**Flow**: API returns 401 → `apiRequest` detects → calls `handleUnauthorized` → clears user/token state → `ProtectedRoute` redirects to `/login`

### Tests (10 new tests)
| File | Tests |
|------|-------|
| `error.spec.tsx` | 4 — message, retry button, reset callback, homepage link |
| `not-found.spec.tsx` | 3 — 404 text, friendly message, homepage link |
| `api-401.spec.ts` | 3 — handler called on 401, not called on 404, no crash without handler |

## Validation
- ✅ **185 frontend tests** passing (35 files)
- ✅ **160 backend tests** passing
- ✅ TypeScript strict — no errors
- ✅ Build succeeds

## Definition of Done
- [x] Global error boundary with retry + CTA
- [x] Custom 404 page
- [x] Loading pages for SSR routes
- [x] 401 auto-redirect (token expiry)
- [x] No redirect loops (handler only fires once)
- [x] Tests for all new features
- [x] Lint passes, build succeeds
- [x] PR linked to issue