### PR TITLE
fix(frontend): make CourseCard a Client Component for image onError handler

### DIFF
--- a/frontend/src/components/course/CourseCard.tsx
+++ b/frontend/src/components/course/CourseCard.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Image from 'next/image'
 import Link from 'next/link'
 import type { Course } from '@/services/types/course'


### PR DESCRIPTION
Marks `CourseCard` as a Client Component so the `<Image>` `onError` handler can run on the client and set a fallback thumbnail. This fixes the runtime error raised by Next.js App Router when passing event handlers to Server Components.

Files changed:
- frontend/src/components/course/CourseCard.tsx

No behavioral changes beyond making the component client-side; parent components remain server components.