### PR TITLE
feat(e2e): implement admin course lifecycle E2E tests (#74)

### DIFF
--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,4 +1,4 @@
-import { apiPost, apiPatch } from './api'
+import { apiPost, apiPatch, apiDelete } from './api'
 
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@dudecourse.local'
 const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || 'Admin@123456'
@@ -161,4 +161,53 @@ export async function seedPublishedCourseWithLessons(
 
   const publishedCourse = await publishCourse(adminToken, course.id)
   return { course: publishedCourse, lessons }
+}
+
+/**
+ * Unpublish a course via admin API.
+ */
+export async function unpublishCourse(
+  adminToken: string,
+  courseId: number,
+): Promise<CourseResponse> {
+  const { status, body } = await apiPatch<CourseResponse>(
+    `/courses/${courseId}/unpublish`,
+    undefined,
+    adminToken,
+  )
+  if (status !== 200) {
+    throw new Error(`Course unpublish failed (${status}): ${JSON.stringify(body)}`)
+  }
+  return (body as { data: CourseResponse }).data
+}
+
+/**
+ * Delete a course via admin API.
+ */
+export async function deleteCourse(
+  adminToken: string,
+  courseId: number,
+): Promise<void> {
+  const { status } = await apiDelete(`/courses/${courseId}`, adminToken)
+  if (status !== 200 && status !== 204) {
+    throw new Error(`Course delete failed (${status})`)
+  }
+}
+
+/**
+ * Reorder lessons via admin API.
+ */
+export async function reorderLessons(
+  adminToken: string,
+  courseId: number,
+  lessons: Array<{ lessonId: number; position: number }>,
+): Promise<void> {
+  const { status, body } = await apiPatch(
+    `/courses/${courseId}/lessons/reorder`,
+    { lessons } as unknown as Record<string, unknown>,
+    adminToken,
+  )
+  if (status !== 200) {
+    throw new Error(`Lesson reorder failed (${status}): ${JSON.stringify(body)}`)
+  }
 }

--- a/e2e/pages/admin-course-form.page.ts
+++ b/e2e/pages/admin-course-form.page.ts
@@ -29,4 +29,12 @@ export class AdminCourseFormPage {
     }
     await this.submitButton.click()
   }
+
+  async gotoNew() {
+    await this.page.goto('/admin/courses/new')
+  }
+
+  async gotoEdit(courseId: number) {
+    await this.page.goto(`/admin/courses/${courseId}/edit`)
+  }
 }

--- a/e2e/pages/admin-lessons.page.ts
+++ b/e2e/pages/admin-lessons.page.ts
@@ -5,12 +5,22 @@ export class AdminLessonsPage {
   readonly addLessonButton: Locator
   readonly lessonReorderList: Locator
   readonly lessonForm: Locator
+  readonly lessonFormTitle: Locator
+  readonly lessonFormYoutubeUrl: Locator
+  readonly lessonFormPosition: Locator
+  readonly lessonFormSubmit: Locator
+  readonly lessonFormCancel: Locator
 
   constructor(page: Page) {
     this.page = page
     this.addLessonButton = page.getByTestId('admin-add-lesson-button')
     this.lessonReorderList = page.getByTestId('lesson-reorder-list')
     this.lessonForm = page.getByTestId('lesson-form')
+    this.lessonFormTitle = page.getByTestId('lesson-form-title')
+    this.lessonFormYoutubeUrl = page.getByTestId('lesson-form-youtube-url')
+    this.lessonFormPosition = page.getByTestId('lesson-form-position')
+    this.lessonFormSubmit = page.getByTestId('lesson-form-submit')
+    this.lessonFormCancel = page.getByTestId('lesson-form-cancel')
   }
 
   async goto(courseId: number) {

--- a/e2e/tests/admin-courses.spec.ts
+++ b/e2e/tests/admin-courses.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect } from '../fixtures/auth.fixture'
+import {
+  loginAsAdmin,
+  reorderLessons,
+} from '../helpers/seed'
+import {
+  AdminCoursesPage,
+  AdminCourseFormPage,
+  AdminLessonsPage,
+  CourseCatalogPage,
+} from '../pages'
+
+/**
+ * E2E — Admin Course Lifecycle (Issue #74)
+ *
+ * Full admin journey:
+ *   Login → Create draft → Add lessons → Reorder → Publish →
+ *   Verify in catalog → Edit → Unpublish → Verify removed → Delete
+ *
+ * Uses test.describe.serial so tests share browser context.
+ * Seed: admin user only (from DB seed).
+ */
+
+let adminToken: string
+let createdCourseId: number
+const lessonIds: number[] = []
+
+const timestamp = Date.now()
+const courseTitle = `Admin E2E Course ${timestamp}`
+const courseDescription = 'E2E test course for admin lifecycle'
+const updatedCourseTitle = `Updated Admin E2E Course ${timestamp}`
+
+test.describe.serial('Admin Course Lifecycle — create → delete', () => {
+  test.beforeAll(async () => {
+    adminToken = await loginAsAdmin()
+  })
+
+  test('Login as admin and access admin area', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    const adminCourses = new AdminCoursesPage(page)
+    await adminCourses.goto()
+
+    // Verify admin courses page loads
+    await expect(adminCourses.createCourseButton).toBeVisible()
+  })
+
+  test('AC1 — Create draft course', async ({ authenticatedAdminPage: page }) => {
+    const adminCourses = new AdminCoursesPage(page)
+    await adminCourses.goto()
+
+    // Click "Novo Curso" button
+    await adminCourses.createCourseButton.click()
+
+    // Fill the course form
+    const courseForm = new AdminCourseFormPage(page)
+    await expect(courseForm.form).toBeVisible()
+    await courseForm.fillCourseForm({
+      title: courseTitle,
+      description: courseDescription,
+    })
+
+    // Should redirect to edit page — extract course ID from URL
+    await page.waitForURL('**/admin/courses/*/edit')
+    const url = page.url()
+    const idMatch = url.match(/\/admin\/courses\/(\d+)\/edit/)
+    expect(idMatch).toBeTruthy()
+    createdCourseId = Number(idMatch![1])
+
+    // Go back to admin list and verify the course card exists with draft status
+    await adminCourses.goto()
+    const courseCard = adminCourses.courseCard(createdCourseId)
+    await expect(courseCard).toBeVisible()
+    await expect(courseCard).toContainText(courseTitle)
+    await expect(courseCard).toContainText('Rascunho')
+  })
+
+  test('AC1.2 — Draft course is NOT visible in public catalog', async ({
+    browser,
+  }) => {
+    // Use a fresh context (no auth) to check public catalog
+    const context = await browser.newContext()
+    const page = await context.newPage()
+    const catalogPage = new CourseCatalogPage(page)
+    await catalogPage.goto()
+
+    // The draft course should NOT appear
+    await expect(catalogPage.courseList).toBeVisible()
+    const courseCard = catalogPage.courseCard(createdCourseId)
+    await expect(courseCard).not.toBeVisible()
+
+    await context.close()
+  })
+
+  test('AC2 — Add 3 lessons to the course', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    const lessonsPage = new AdminLessonsPage(page)
+    await lessonsPage.goto(createdCourseId)
+
+    const lessons = [
+      {
+        title: 'Intro to Testing',
+        youtubeUrl: 'https://www.youtube.com/watch?v=admin-e2e-1',
+        position: '1',
+      },
+      {
+        title: 'Advanced Patterns',
+        youtubeUrl: 'https://www.youtube.com/watch?v=admin-e2e-2',
+        position: '2',
+      },
+      {
+        title: 'Best Practices',
+        youtubeUrl: 'https://www.youtube.com/watch?v=admin-e2e-3',
+        position: '3',
+      },
+    ]
+
+    for (const lessonData of lessons) {
+      await lessonsPage.addLessonButton.click()
+      await expect(lessonsPage.lessonForm).toBeVisible()
+
+      await lessonsPage.lessonFormTitle.fill(lessonData.title)
+      await lessonsPage.lessonFormYoutubeUrl.fill(lessonData.youtubeUrl)
+      await lessonsPage.lessonFormPosition.fill('')
+      await lessonsPage.lessonFormPosition.fill(lessonData.position)
+      await lessonsPage.lessonFormSubmit.click()
+
+      // Wait for the form/modal to close
+      await expect(lessonsPage.lessonForm).not.toBeVisible()
+    }
+
+    // Verify all 3 lessons are visible in the reorder list
+    await expect(lessonsPage.lessonReorderList).toBeVisible()
+
+    // Extract lesson IDs from the DOM for later use
+    const lessonItems = page.locator('[data-testid^="lesson-reorder-item-"]')
+    const count = await lessonItems.count()
+    expect(count).toBe(3)
+
+    for (let i = 0; i < count; i++) {
+      const testId = await lessonItems.nth(i).getAttribute('data-testid')
+      const id = Number(testId!.replace('lesson-reorder-item-', ''))
+      lessonIds.push(id)
+    }
+  })
+
+  test('AC2.2 — Reorder lessons via API and verify UI', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    // Reorder lessons: swap position of first and third via API
+    await reorderLessons(adminToken, createdCourseId, [
+      { lessonId: lessonIds[0], position: 3 },
+      { lessonId: lessonIds[1], position: 1 },
+      { lessonId: lessonIds[2], position: 2 },
+    ])
+
+    // Refresh the lessons page and verify new order
+    const lessonsPage = new AdminLessonsPage(page)
+    await lessonsPage.goto(createdCourseId)
+
+    const lessonItems = page.locator('[data-testid^="lesson-reorder-item-"]')
+    const count = await lessonItems.count()
+    expect(count).toBe(3)
+
+    // First item should now be lessonIds[1] (moved to position 1)
+    const firstTestId = await lessonItems.first().getAttribute('data-testid')
+    expect(firstTestId).toBe(`lesson-reorder-item-${lessonIds[1]}`)
+  })
+
+  test('AC3 — Publish course and verify in catalog', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    const adminCourses = new AdminCoursesPage(page)
+    await adminCourses.goto()
+
+    // Click publish button
+    const publishBtn = adminCourses.publishButton(createdCourseId)
+    await expect(publishBtn).toBeVisible()
+    await publishBtn.click()
+
+    // Card should now show "Publicado"
+    const courseCard = adminCourses.courseCard(createdCourseId)
+    await expect(courseCard).toContainText('Publicado')
+
+    // Verify course appears in public catalog (fresh context, no auth)
+    const context = await page.context().browser()!.newContext()
+    const publicPage = await context.newPage()
+    const catalogPage = new CourseCatalogPage(publicPage)
+    await catalogPage.goto()
+
+    await expect(catalogPage.courseCard(createdCourseId)).toBeVisible()
+    await expect(catalogPage.courseCard(createdCourseId)).toContainText(courseTitle)
+
+    await context.close()
+  })
+
+  test('AC3.2 — Edit published course', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    const courseForm = new AdminCourseFormPage(page)
+    await courseForm.gotoEdit(createdCourseId)
+
+    // Update title
+    await courseForm.titleInput.clear()
+    await courseForm.titleInput.fill(updatedCourseTitle)
+    await courseForm.submitButton.click()
+
+    // Verify success feedback
+    await expect(page.getByText('Curso atualizado com sucesso')).toBeVisible()
+  })
+
+  test('AC4 — Unpublish course removes from catalog', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    const adminCourses = new AdminCoursesPage(page)
+    await adminCourses.goto()
+
+    // Click unpublish — triggers confirmation modal
+    const unpublishBtn = adminCourses.unpublishButton(createdCourseId)
+    await expect(unpublishBtn).toBeVisible()
+    await unpublishBtn.click()
+
+    // Confirm in the modal
+    await expect(page.getByTestId('confirm-modal-message')).toBeVisible()
+    await page.getByTestId('confirm-modal-confirm').click()
+
+    // Wait for card to update — should now show "Despublicado"
+    const courseCard = adminCourses.courseCard(createdCourseId)
+    await expect(courseCard).toContainText('Despublicado')
+
+    // Verify course is NOT in public catalog
+    const context = await page.context().browser()!.newContext()
+    const publicPage = await context.newPage()
+    const catalogPage = new CourseCatalogPage(publicPage)
+    await catalogPage.goto()
+
+    await expect(catalogPage.courseCard(createdCourseId)).not.toBeVisible()
+
+    await context.close()
+  })
+
+  test('AC5 — Delete course removes from admin list', async ({
+    authenticatedAdminPage: page,
+  }) => {
+    const adminCourses = new AdminCoursesPage(page)
+    await adminCourses.goto()
+
+    // Course card should be visible before delete
+    await expect(adminCourses.courseCard(createdCourseId)).toBeVisible()
+
+    // Click delete — triggers confirmation modal
+    const deleteBtn = adminCourses.deleteButton(createdCourseId)
+    await deleteBtn.click()
+
+    // Confirm in the modal
+    await expect(page.getByTestId('confirm-modal-message')).toBeVisible()
+    await page.getByTestId('confirm-modal-confirm').click()
+
+    // Course card should disappear from the admin list
+    await expect(adminCourses.courseCard(createdCourseId)).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Implements the full admin course lifecycle E2E test suite as defined in issue #74.

### Changes

**New files:**
- `e2e/tests/admin-courses.spec.ts` — Serial test suite with 8 tests covering admin CRUD + publish lifecycle

**Modified files:**
- `e2e/helpers/seed.ts` — Added `unpublishCourse()`, `deleteCourse()`, `reorderLessons()` helpers
- `e2e/pages/admin-course-form.page.ts` — Added `gotoNew()` and `gotoEdit(courseId)` navigation methods
- `e2e/pages/admin-lessons.page.ts` — Added lesson form field locators (`lessonFormTitle`, `lessonFormYoutubeUrl`, `lessonFormPosition`, `lessonFormSubmit`, `lessonFormCancel`)

### Acceptance Criteria Coverage

- ✅ **AC1** — Create draft: course created via UI, appears with "Rascunho" badge, NOT in public catalog
- ✅ **AC2** — Add & reorder lessons: 3 lessons added via modal form, reordered via API + UI verification
- ✅ **AC3** — Publish & catalog: publish button changes status, course appears in public catalog
- ✅ **AC4** — Unpublish: confirmation modal, course disappears from public catalog
- ✅ **AC5** — Delete: confirmation modal, course removed from admin list

### Test Strategy
- `test.describe.serial` — admin creates course in first test, subsequent tests modify it
- DnD reorder tested via API call + UI refresh verification (per architect recommendation)
- Fresh browser contexts (no auth) used to verify public catalog visibility/invisibility
- Confirmation modals tested using `data-testid` selectors

Closes #74