### PR TITLE
docs: documentation improvements after E2E Wave 2 completion

### DIFF
--- a/CONTEXT_PACK.md
+++ b/CONTEXT_PACK.md
@@ -42,8 +42,13 @@ Frontend
 
 E2E Testing
 - Playwright (browser-based E2E tests)
-- Page Object Model (POM) pattern
-- data-testid selectors
+- Page Object Model (POM) pattern — 1 class per page in e2e/pages/
+- data-testid selectors exclusively
+- Auth fixtures: authenticatedLearnerPage, authenticatedAdminPage
+- Seed helpers: HTTP API calls via e2e/helpers/seed.ts (no direct DB access)
+- Test suites: smoke, learner-journey, admin-courses, auth-protection, idempotency, validation-security
+- workers: 1 (serial execution for journey tests)
+- CI: .github/workflows/ci-e2e.yml
 
 Database
 - MySQL 8.0

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Executa lint (type-check) + testes unitários do backend. Roda automaticamente n
 | `pnpm dev:frontend` | Sobe apenas o frontend |
 | `pnpm dev:db` | Sobe o MySQL via Docker (Docker Compose) |
 | `pnpm test` | Roda todos os testes do monorepo |
+| `pnpm e2e` | Roda todos os testes E2E (headless, inicia backend + frontend automaticamente) |
+| `pnpm e2e:ui` | Testes E2E com Playwright UI (modo interativo) |
+| `pnpm e2e:headed` | Testes E2E com browser visível |
 | `pnpm build` | Builda todos os pacotes |
 
 > Para setup detalhado (env vars, banco de testes, etc.), consulte [`docs/local-setup.md`](docs/local-setup.md).

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -267,7 +267,10 @@ pnpm --filter e2e exec playwright install --with-deps chromium
 pnpm e2e                # rodar todos (headless)
 pnpm e2e:ui             # modo UI interativo do Playwright
 pnpm e2e:headed         # rodar com browser visível
+pnpm e2e:debug          # modo debug (Playwright Inspector)
 ```
+
+> Para sobrescrever as variáveis padrão, crie `e2e/.env` com os valores desejados. Consulte [`e2e/README.md`](../e2e/README.md#environment-variables) para detalhes.
 
 ### Todos os testes do monorepo
 

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,8 @@
+# E2E test environment variables
+# Copy this file to .env and override only what you need to change
+# All values below are the defaults — the test suite works without creating .env
+
+E2E_BASE_URL=http://localhost:3000
+E2E_API_URL=http://localhost:3001/api/v1
+E2E_ADMIN_EMAIL=admin@dudecourse.local
+E2E_ADMIN_PASSWORD=Admin@123456

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -3,3 +3,4 @@ test-results/
 playwright-report/
 blob-report/
 .playwright/
+.env

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -34,11 +34,26 @@ pnpm e2e:ui
 # Run in headed browser (see the browser)
 pnpm e2e:headed
 
+# Run in debug mode (step through tests with Playwright Inspector)
+pnpm e2e:debug
+
 # Run from e2e/ directory
 cd e2e && pnpm test
 ```
 
 > **Note**: If backend and frontend are already running, Playwright will reuse them (`reuseExistingServer: true` in local mode).
+
+### Viewing test reports
+
+After a test run, Playwright generates an HTML report in `e2e/playwright-report/`.
+
+Open it with:
+
+```bash
+cd e2e && npx playwright show-report
+```
+
+> In CI, the report is uploaded as a GitHub Actions artifact (14-day retention).
 
 ## Project structure
 
@@ -63,8 +78,24 @@ e2e/
     admin-lessons.page.ts
     index.ts              # Re-exports all Page Objects
   tests/                  # Test specs
-    smoke.spec.ts         # Infrastructure smoke test
+    smoke.spec.ts              # Infrastructure smoke (health, pages reachable)
+    learner-journey.spec.ts    # Full learner flow: register → enroll → progress → certificate
+    admin-courses.spec.ts      # Admin flow: create → publish → edit → delete
+    auth-protection.spec.ts    # Auth redirects, role enforcement, invalid credentials
+    idempotency.spec.ts        # Idempotency: enrollment, progress, certificate (pure API)
+    validation-security.spec.ts # Form validation, draft/unpublished access, requestId in errors
 ```
+
+## Test coverage
+
+| Spec file | What it covers | Type |
+|-----------|----------------|------|
+| `smoke.spec.ts` | Health endpoint, public pages, login page reachable | UI |
+| `learner-journey.spec.ts` | Register, login, browse catalog, enroll, watch lesson, complete progress, certificate, dashboard | UI (serial) |
+| `admin-courses.spec.ts` | Create draft, add/reorder lessons, publish, edit, unpublish, delete | UI (serial) |
+| `auth-protection.spec.ts` | Unauthenticated redirects, learner blocked from admin, invalid credentials, 401 handler | UI |
+| `idempotency.spec.ts` | Double enrollment (201→200), double lesson progress (no inflation), double certificate (same code) | API (headless) |
+| `validation-security.spec.ts` | Client-side form validation (Zod), draft/unpublished course 404, `requestId` in API errors | UI + API |
 
 ## Conventions
 
@@ -137,6 +168,15 @@ test.beforeAll(async () => {
 | `E2E_API_URL` | `http://localhost:3001/api/v1` | Backend API URL |
 | `E2E_ADMIN_EMAIL` | `admin@dudecourse.local` | Admin email (from seed) |
 | `E2E_ADMIN_PASSWORD` | `Admin@123456` | Admin password (from seed) |
+
+> To override defaults locally, create `e2e/.env`:
+> ```env
+> E2E_BASE_URL=http://localhost:3000
+> E2E_API_URL=http://localhost:3001/api/v1
+> E2E_ADMIN_EMAIL=admin@dudecourse.local
+> E2E_ADMIN_PASSWORD=Admin@123456
+> ```
+> The file is gitignored. Values above are the defaults — only add entries you want to change.
 
 ## CI
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "e2e": "pnpm --filter e2e test",
     "e2e:ui": "pnpm --filter e2e test:ui",
     "e2e:headed": "pnpm --filter e2e test:headed",
+    "e2e:debug": "pnpm --filter e2e test:debug",
     "validate": "pnpm lint && pnpm --filter backend test",
     "prepare": "husky"
   },


### PR DESCRIPTION
Closes #82

## Summary

Post-merge documentation improvements after completing the full E2E test suite (Wave 0–2). No code changes — purely documentation and tooling.

---

## Files Changed

| File | AC | Change |
|------|----|--------|
| `e2e/README.md` | AC1 | Project structure `tests/` block lists all 6 spec files with descriptions |
| `e2e/README.md` | AC2 | New **Test coverage** table showing what each spec covers and its type |
| `e2e/README.md` | AC3 | `pnpm e2e:debug` command + **Viewing test reports** subsection |
| `e2e/README.md` | AC4 | `.env` override instructions added to Environment variables section |
| `e2e/.env.example` | AC4 | New file — template for local env overrides |
| `e2e/.gitignore` | bonus | Added `.env` to prevent accidental commits |
| `README.md` | AC5 | Scripts table now includes `pnpm e2e`, `pnpm e2e:ui`, `pnpm e2e:headed` |
| `docs/local-setup.md` | AC6 | E2E section adds `pnpm e2e:debug` + note linking to `e2e/README.md` for `.env` override |
| `CONTEXT_PACK.md` | AC7 | E2E Testing section expanded from 3 lines to 8 (POM, fixtures, seed helpers, 6 suites, CI) |
| `package.json` | bonus | Added `"e2e:debug"` script so `pnpm e2e:debug` works from repo root |

---

## Acceptance Criteria

- [x] AC1 — `e2e/README.md` lists all 6 spec files with one-line descriptions
- [x] AC2 — `e2e/README.md` has **Test coverage** table (6 rows, Type column)
- [x] AC3 — `e2e/README.md` documents `test:debug` and report viewing
- [x] AC4 — `e2e/README.md` has `.env` override instructions + `e2e/.env.example` created
- [x] AC5 — Root `README.md` scripts table includes `pnpm e2e`, `e2e:ui`, `e2e:headed`
- [x] AC6 — `docs/local-setup.md` E2E section has `e2e:debug` + `.env` override note
- [x] AC7 — `CONTEXT_PACK.md` E2E section reflects all 6 test suites and key infrastructure