### PR TITLE
fix: resolve 3 bugs blocking E2E tests (#84)

### DIFF
--- a/backend/src/controllers/admin-course-controller.ts
+++ b/backend/src/controllers/admin-course-controller.ts
@@ -2,6 +2,7 @@ import type { FastifyRequest, FastifyReply } from 'fastify'
 import type { AdminCourseService } from '../services/admin-course-service.js'
 import {
   AdminCourseIdParamSchema,
+  AdminListCoursesQuerySchema,
   CreateCourseBodySchema,
   UpdateCourseBodySchema,
 } from '../dto/admin-course-dto.js'
@@ -10,6 +11,21 @@ import { logger } from '../utils/logger.js'
 
 export class AdminCourseController {
   constructor(private readonly adminCourseService: AdminCourseService) {}
+
+  async list(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const query = AdminListCoursesQuerySchema.parse(request.query)
+
+    const result = await this.adminCourseService.listAll(query.page, query.pageSize)
+
+    const data = result.data.map((course) => this.formatCourse(course))
+
+    logger.info(
+      { requestId: request.id, page: query.page, pageSize: query.pageSize },
+      'admin.courses.listed',
+    )
+
+    return reply.status(200).send({ data, meta: result.meta, requestId: request.id })
+  }
 
   async create(request: FastifyRequest, reply: FastifyReply): Promise<void> {
     const body = CreateCourseBodySchema.parse(request.body)

--- a/backend/src/dto/admin-course-dto.ts
+++ b/backend/src/dto/admin-course-dto.ts
@@ -8,6 +8,15 @@ export const AdminCourseIdParamSchema = z.object({
 
 export type AdminCourseIdParamDto = z.infer<typeof AdminCourseIdParamSchema>
 
+// ── Query Params ──────────────────────────────────────────────
+
+export const AdminListCoursesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+})
+
+export type AdminListCoursesQueryDto = z.infer<typeof AdminListCoursesQuerySchema>
+
 // ── Request Bodies ────────────────────────────────────────────
 
 export const CreateCourseBodySchema = z.object({

--- a/backend/src/repositories/course-repository.ts
+++ b/backend/src/repositories/course-repository.ts
@@ -7,6 +7,8 @@ export interface ICourseRepository {
   findById(id: number): Promise<Course | null>
   findByStatus(status: CourseStatus): Promise<Course[]>
   findPublished(page: number, pageSize: number): Promise<Course[]>
+  findAll(page: number, pageSize: number): Promise<Course[]>
+  countAll(): Promise<number>
   countByStatus(status: CourseStatus): Promise<number>
   update(id: number, data: Partial<CreateCourseData>): Promise<Course | null>
   delete(id: number): Promise<boolean>
@@ -61,6 +63,20 @@ export class PrismaCourseRepository implements ICourseRepository {
     return prisma.course.count({
       where: { status },
     })
+  }
+
+  async findAll(page: number, pageSize: number): Promise<Course[]> {
+    const courses = await prisma.course.findMany({
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return courses.map((c) => this.mapToCourse(c))
+  }
+
+  async countAll(): Promise<number> {
+    return prisma.course.count()
   }
 
   async update(

--- a/backend/src/routes/admin-course-routes.ts
+++ b/backend/src/routes/admin-course-routes.ts
@@ -4,6 +4,7 @@ import { authMiddleware } from '../middlewares/auth.js'
 import { adminGuardMiddleware } from '../middlewares/admin-guard.js'
 import {
   AdminCourseIdParamSchema,
+  AdminListCoursesQuerySchema,
   CreateCourseBodySchema,
   UpdateCourseBodySchema,
 } from '../dto/admin-course-dto.js'
@@ -11,6 +12,7 @@ import { zodToJsonSchema } from '../utils/zod-to-json-schema.js'
 import {
   errorResponseSchema,
   successResponse,
+  paginatedResponse,
   courseResponseSchema,
 } from '../dto/openapi-schemas.js'
 
@@ -19,6 +21,26 @@ export async function adminCourseRoutes(
   controller: AdminCourseController,
 ): Promise<void> {
   const preHandler = [authMiddleware, adminGuardMiddleware]
+
+  app.get(
+    '/admin/courses',
+    {
+      schema: {
+        tags: ['Admin: Courses'],
+        summary: 'List all courses (admin)',
+        description: 'Lists all courses regardless of status, with pagination. Requires admin role.',
+        security: [{ bearerAuth: [] }],
+        querystring: zodToJsonSchema(AdminListCoursesQuerySchema),
+        response: {
+          200: paginatedResponse(courseResponseSchema),
+          401: errorResponseSchema,
+          403: errorResponseSchema,
+        },
+      },
+      preHandler,
+    },
+    (request, reply) => controller.list(request, reply),
+  )
 
   app.post(
     '/courses',

--- a/backend/src/routes/admin-course-routes.ts
+++ b/backend/src/routes/admin-course-routes.ts
@@ -33,6 +33,7 @@ export async function adminCourseRoutes(
         querystring: zodToJsonSchema(AdminListCoursesQuerySchema),
         response: {
           200: paginatedResponse(courseResponseSchema),
+          400: errorResponseSchema,
           401: errorResponseSchema,
           403: errorResponseSchema,
         },

--- a/backend/src/services/admin-course-service.ts
+++ b/backend/src/services/admin-course-service.ts
@@ -21,6 +21,26 @@ export class AdminCourseService {
     private readonly lessonRepository: ILessonRepository,
   ) {}
 
+  async listAll(
+    page: number,
+    pageSize: number,
+  ): Promise<{
+    data: Course[]
+    meta: { page: number; pageSize: number; totalItems: number; totalPages: number }
+  }> {
+    const [courses, totalItems] = await Promise.all([
+      this.courseRepository.findAll(page, pageSize),
+      this.courseRepository.countAll(),
+    ])
+
+    const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / pageSize)
+
+    return {
+      data: courses,
+      meta: { page, pageSize, totalItems, totalPages },
+    }
+  }
+
   async create(data: CreateCourseInput): Promise<Course> {
     const courseData: CreateCourseData = {
       title: data.title,

--- a/backend/test/unit/services/admin-course-service.spec.ts
+++ b/backend/test/unit/services/admin-course-service.spec.ts
@@ -9,8 +9,10 @@ function createMockCourseRepository(): ICourseRepository {
   return {
     create: vi.fn(),
     findById: vi.fn(),
+    findAll: vi.fn(),
     findByStatus: vi.fn(),
     findPublished: vi.fn(),
+    countAll: vi.fn(),
     countByStatus: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -175,6 +177,50 @@ describe('AdminCourseService', () => {
 
       await expect(service.delete(999)).rejects.toThrow(NotFoundError)
       await expect(service.delete(999)).rejects.toThrow('Course not found')
+    })
+  })
+
+  // ────────────────────────────────────────
+  // listAll
+  // ────────────────────────────────────────
+  describe('listAll', () => {
+    it('should return paginated results with courses and meta', async () => {
+      const courses = [
+        {
+          id: 1,
+          title: 'Course 1',
+          description: 'Description 1',
+          thumbnailUrl: null,
+          status: 'draft' as const,
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+        {
+          id: 2,
+          title: 'Course 2',
+          description: 'Description 2',
+          thumbnailUrl: null,
+          status: 'draft' as const,
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ]
+
+      vi.mocked(mockCourseRepo.findAll).mockResolvedValue(courses)
+      vi.mocked(mockCourseRepo.countAll).mockResolvedValue(2)
+
+      const result = await service.listAll(1, 20)
+
+      expect(result.data).toEqual(courses)
+      expect(result.data).toHaveLength(2)
+      expect(result.meta).toEqual({
+        page: 1,
+        pageSize: 20,
+        totalItems: 2,
+        totalPages: 1,
+      })
+      expect(mockCourseRepo.findAll).toHaveBeenCalledWith(1, 20)
+      expect(mockCourseRepo.countAll).toHaveBeenCalledOnce()
     })
   })
 })

--- a/backend/test/unit/services/admin-lesson-service.spec.ts
+++ b/backend/test/unit/services/admin-lesson-service.spec.ts
@@ -9,8 +9,10 @@ function createMockCourseRepository(): ICourseRepository {
   return {
     create: vi.fn(),
     findById: vi.fn(),
+    findAll: vi.fn(),
     findByStatus: vi.fn(),
     findPublished: vi.fn(),
+    countAll: vi.fn(),
     countByStatus: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),

--- a/backend/test/unit/services/certificate-service.spec.ts
+++ b/backend/test/unit/services/certificate-service.spec.ts
@@ -32,8 +32,10 @@ function createMockCourseRepository(): ICourseRepository {
   return {
     create: vi.fn(),
     findById: vi.fn(),
+    findAll: vi.fn(),
     findByStatus: vi.fn(),
     findPublished: vi.fn(),
+    countAll: vi.fn(),
     countByStatus: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),

--- a/backend/test/unit/services/course-service.spec.ts
+++ b/backend/test/unit/services/course-service.spec.ts
@@ -9,8 +9,10 @@ function createMockCourseRepository(): ICourseRepository {
   return {
     create: vi.fn(),
     findById: vi.fn(),
+    findAll: vi.fn(),
     findByStatus: vi.fn(),
     findPublished: vi.fn(),
+    countAll: vi.fn(),
     countByStatus: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),

--- a/backend/test/unit/services/dashboard-service.spec.ts
+++ b/backend/test/unit/services/dashboard-service.spec.ts
@@ -21,8 +21,10 @@ function createMockCourseRepository(): ICourseRepository {
   return {
     create: vi.fn(),
     findById: vi.fn(),
+    findAll: vi.fn(),
     findByStatus: vi.fn(),
     findPublished: vi.fn(),
+    countAll: vi.fn(),
     countByStatus: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),

--- a/backend/test/unit/services/enrollment-service.spec.ts
+++ b/backend/test/unit/services/enrollment-service.spec.ts
@@ -26,8 +26,10 @@ function createMockCourseRepository(): ICourseRepository {
   return {
     create: vi.fn(),
     findById: vi.fn(),
+    findAll: vi.fn(),
     findByStatus: vi.fn(),
     findPublished: vi.fn(),
+    countAll: vi.fn(),
     countByStatus: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -443,6 +443,48 @@ Exemplo de resposta (503):
 
 Todas as rotas admin exigem `Authorization: Bearer <token>` com `role: admin`. Learners recebem `403 FORBIDDEN`.
 
+### GET /admin/courses
+
+Lista todos os cursos independente do status (draft, published, unpublished), com paginação. Endpoint exclusivo para administradores.
+
+**Auth:** Sim (admin)
+
+#### Query Params (opcional)
+- `page` (default: 1)
+- `pageSize` (default: 20, max: 100)
+
+#### Response
+- **200 OK**
+- **401 Unauthorized**
+- **403 Forbidden**
+
+Exemplo de resposta (200):
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "title": "New Course",
+      "description": "A great course",
+      "thumbnailUrl": null,
+      "status": "draft",
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "pageSize": 20,
+    "totalItems": 3,
+    "totalPages": 1
+  },
+  "requestId": "req_123"
+}
+```
+
+---
+
 ### POST /courses
 
 Cria um novo curso (status inicial: `draft`).
@@ -518,6 +560,8 @@ Publica um curso existente.
 
 **Auth:** Sim (admin)
 
+> **Nota:** esta rota não aceita corpo na requisição. Enviar `Content-Type: application/json` sem body pode causar erro 400.
+
 #### Path Params
 - `id` (number)
 
@@ -542,6 +586,8 @@ Exemplo de resposta (200): Course com `"status": "published"`.
 Despublica um curso, tornando-o invisível no catálogo.
 
 **Auth:** Sim (admin)
+
+> **Nota:** esta rota não aceita corpo na requisição. Enviar `Content-Type: application/json` sem body pode causar erro 400.
 
 #### Path Params
 - `id` (number)
@@ -744,6 +790,7 @@ Todas as operações de escrita abaixo são **idempotentes** — chamadas repeti
 - [x] Dashboard do learner
 - [x] Certificados idempotentes
 - [x] Admin CRUD de cursos
+- [x] Admin listing de cursos (GET /admin/courses)
 - [x] Admin CRUD de lessons
 - [x] Admin publish/unpublish
 - [x] Admin reorder lessons

--- a/docs/engineer-guidelines.md
+++ b/docs/engineer-guidelines.md
@@ -98,12 +98,32 @@ ADRs registram decisões arquiteturais significativas do projeto. Cada ADR é um
 - **Quando NÃO usar E2E**: validação de lógica de negócio isolada (usar unit test), queries de repositório (usar integration test)
 - **Decisão**: ADR-0010
 
+### SSR/Streaming e E2E
+- Next.js com streaming SSR pode renderizar o mesmo `data-testid` múltiplas vezes durante o ciclo de streaming (shell + conteúdo final).
+- Em locators Playwright que referenciam testids em áreas afetadas por streaming, usar `.first()` para evitar erros de "strict mode violation" (ex: `page.getByTestId('course-list').first()`).
+- Documentar no Page Object o motivo do `.first()` para manutenibilidade.
+
 ### Regras
 - Cada Use Case deve ter testes de:
   - fluxo feliz
   - validação de entrada
   - casos de erro esperados (ex.: curso não existe)
 - Use Cases devem ser testados com **mocks das ports** (interfaces), não com DB real.
+
+---
+
+## 🌐 HTTP Client Conventions
+
+### Content-Type Header
+- Incluir `Content-Type: application/json` **somente quando a requisição contiver body**.
+- Requisições sem body (ex.: PATCH de publish/unpublish, DELETE) **não devem** enviar o header `Content-Type`.
+- Fastify retorna `400 Bad Request` se receber `Content-Type: application/json` com body vazio/undefined.
+- Regra aplicável ao frontend (`frontend/src/services/api.ts`) e ao helper E2E (`e2e/helpers/api.ts`).
+
+### Padrão para helpers de API (E2E)
+- `apiPost` / `apiPut`: sempre inclui `Content-Type: application/json` (body obrigatório).
+- `apiPatch`: inclui `Content-Type` **somente** quando `body !== undefined`.
+- `apiGet` / `apiDelete`: **nunca** inclui `Content-Type`.
 
 ---
 
@@ -237,8 +257,8 @@ Uma tarefa só é “done” quando:
 - [ ] endpoints aderentes a `docs/api-spec.md`
 - [ ] migrations incluídas quando houver alteração de schema
 - [ ] logs e tratamento de erro adequados
-- [ ] documentação atualizada (se necessário)
-
+- [ ] documentação atualizada (se necessário)- [ ] HTTP client não envia `Content-Type` em requisições sem body
+- [ ] locators E2E resilientes a streaming SSR (`.first()` quando necessário)
 ---
 
 ## 🤖 Regras para IA (Copilot / Agents)

--- a/docs/engineer-guidelines.md
+++ b/docs/engineer-guidelines.md
@@ -257,7 +257,8 @@ Uma tarefa só é “done” quando:
 - [ ] endpoints aderentes a `docs/api-spec.md`
 - [ ] migrations incluídas quando houver alteração de schema
 - [ ] logs e tratamento de erro adequados
-- [ ] documentação atualizada (se necessário)- [ ] HTTP client não envia `Content-Type` em requisições sem body
+- [ ] documentação atualizada (se necessário)
+- [ ] HTTP client não envia `Content-Type` em requisições sem body
 - [ ] locators E2E resilientes a streaming SSR (`.first()` quando necessário)
 ---
 

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -61,8 +61,9 @@ export async function apiPatch<T = unknown>(
   body?: Record<string, unknown>,
   token?: string,
 ): Promise<ApiResult<T>> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
+  const headers: Record<string, string> = {}
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json'
   }
   if (token) {
     headers['Authorization'] = `Bearer ${token}`

--- a/e2e/pages/course-catalog.page.ts
+++ b/e2e/pages/course-catalog.page.ts
@@ -10,7 +10,7 @@ export class CourseCatalogPage {
   constructor(page: Page) {
     this.page = page
     this.courseList = page.getByTestId('course-list').first()
-    this.paginationPrev = page.getByTestId('pagination-prev')
+    this.paginationPrev = page.getByTestId('pagination-prev').first() // .first() is required because Next.js streaming SSR can duplicate this test id in strict mode
     this.paginationNext = page.getByTestId('pagination-next')
     this.paginationInfo = page.getByTestId('pagination-info')
   }

--- a/e2e/pages/course-catalog.page.ts
+++ b/e2e/pages/course-catalog.page.ts
@@ -9,7 +9,7 @@ export class CourseCatalogPage {
 
   constructor(page: Page) {
     this.page = page
-    this.courseList = page.getByTestId('course-list')
+    this.courseList = page.getByTestId('course-list').first()
     this.paginationPrev = page.getByTestId('pagination-prev')
     this.paginationNext = page.getByTestId('pagination-next')
     this.paginationInfo = page.getByTestId('pagination-info')

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -30,6 +30,6 @@ test.describe('E2E Infrastructure Smoke Test', () => {
 
   test('courses catalog page loads', async ({ page }) => {
     await page.goto('/courses')
-    await expect(page.getByTestId('course-list')).toBeVisible()
+    await expect(page.getByTestId('course-list').first()).toBeVisible()
   })
 })

--- a/frontend/src/services/admin-course-service.ts
+++ b/frontend/src/services/admin-course-service.ts
@@ -15,13 +15,14 @@ export interface UpdateCourseInput {
 
 /**
  * Lista todos os cursos (admin vê todos os status).
+ * Chama o endpoint admin GET /admin/courses que retorna cursos de qualquer status.
  */
 export async function listAllCourses(
   page = 1,
   pageSize = 100,
 ): Promise<{ courses: Course[]; meta: PaginationMeta }> {
   const { data, ...rest } = await apiRequest<Course[]>(
-    `/courses?page=${page}&pageSize=${pageSize}`,
+    `/admin/courses?page=${page}&pageSize=${pageSize}`,
   )
   return {
     courses: data,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -58,7 +58,7 @@ export async function apiRequest<T = unknown>(
   const { body, headers: optionHeaders, ...restOptions } = options
 
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
+    ...(body !== undefined && { 'Content-Type': 'application/json' }),
     ...(optionHeaders as Record<string, string>),
   }
 


### PR DESCRIPTION
## Summary

Resolves the 3 bugs identified in issue #84 that were causing 29/40 E2E test failures.

### Bug 1 — Content-Type on bodyless requests (blocked 22 tests)
HTTP clients (E2E helper + frontend `apiRequest`) were always sending `Content-Type: application/json`, even on PATCH requests without a body (publish/unpublish). Fastify rejects this with 400.

**Fix:** Only include `Content-Type` header when `body !== undefined`.

**Files:**
- `e2e/helpers/api.ts` — `apiPatch` conditional header
- `frontend/src/services/api.ts` — `apiRequest` conditional header

### Bug 2 — Missing admin course listing endpoint (blocked 8 tests)
The frontend admin panel called `GET /courses` (public, returns only `published`). No backend endpoint existed for admin to list courses of all statuses.

**Fix:** Add `GET /api/v1/admin/courses` endpoint with pagination, full MVC implementation.

**Files:**
- `backend/src/repositories/course-repository.ts` — `findAll()` + `countAll()` on interface and implementation
- `backend/src/dto/admin-course-dto.ts` — `AdminListCoursesQuerySchema`
- `backend/src/services/admin-course-service.ts` — `listAll()` method
- `backend/src/controllers/admin-course-controller.ts` — `list()` handler
- `backend/src/routes/admin-course-routes.ts` — `GET /admin/courses` route
- `frontend/src/services/admin-course-service.ts` — calls `/admin/courses` instead of `/courses`

### Bug 3 — Duplicate `data-testid` from SSR streaming (blocked 1 test)
Next.js streaming SSR renders `data-testid="course-list"` twice (shell + final content), causing Playwright strict mode violation.

**Fix:** Use `.first()` on affected locators.

**Files:**
- `e2e/tests/smoke.spec.ts`
- `e2e/pages/course-catalog.page.ts`

### Tests
- New unit test for `AdminCourseService.listAll()` happy path
- Updated 6 test files with `findAll`/`countAll` mock methods for `ICourseRepository`
- All 161 backend unit tests pass ✅

### Documentation updates (from documenter analysis)
- `docs/api-spec.md` — Documented `GET /admin/courses`, added "no body" annotations on publish/unpublish
- `docs/engineer-guidelines.md` — Added HTTP Client Conventions section, SSR/Streaming E2E guidance, updated DoD checklist

### Checklist
- [x] Code follows `docs/architecture.md` (MVC layers)
- [x] API matches `docs/api-spec.md` (updated)
- [x] Tests exist and pass (161/161)
- [x] Lint/type-check passes across all packages
- [x] Logging includes `requestId`
- [x] Security rules respected (admin preHandler on new endpoint)
- [x] Documentation updated

Closes #84