### PR TITLE
feat(e2e): add pnpm e2e:report — run tests and open HTML report if all pass

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,6 +28,9 @@ pnpm --filter database db:seed
 # Run all E2E tests (starts backend + frontend automatically)
 pnpm e2e
 
+# Run tests and open HTML report automatically if all pass
+pnpm e2e:report
+
 # Run with Playwright UI (interactive mode)
 pnpm e2e:ui
 
@@ -47,7 +50,9 @@ cd e2e && pnpm test
 
 After a test run, Playwright generates an HTML report in `e2e/playwright-report/`.
 
-Open it with:
+Use `pnpm e2e:report` to run tests and open the report automatically — **the report only opens if all tests pass**.
+
+To open the report from a previous run:
 
 ```bash
 cd e2e && npx playwright show-report

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "playwright test",
+    "test:report": "playwright test --reporter=line && playwright show-report",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "pnpm -r --if-present lint",
     "format": "pnpm -r --if-present format",
     "e2e": "pnpm --filter e2e test",
+    "e2e:report": "pnpm --filter e2e test:report",
     "e2e:ui": "pnpm --filter e2e test:ui",
     "e2e:headed": "pnpm --filter e2e test:headed",
     "e2e:debug": "pnpm --filter e2e test:debug",


### PR DESCRIPTION
## O que muda

Adiciona o comando `pnpm e2e:report` que executa os testes E2E e, **somente se todos passarem**, abre o relatório HTML do Playwright automaticamente.

O `&&` garante que `playwright show-report` só é chamado quando o exit code dos testes é `0`.

## Arquivos alterados

- **`e2e/package.json`** — novo script `test:report`
- **`package.json`** — novo script `e2e:report` na raiz do monorepo
- **`e2e/README.md`** — documentação do novo comando e atualização da seção "Viewing test reports"

## Uso

```bash
pnpm e2e:report
```

- ✅ Todos passaram → abre o relatório HTML no browser
- ❌ Algum falhou → encerra sem abrir (use `pnpm e2e` + `cd e2e && npx playwright show-report` para inspecionar falhas)